### PR TITLE
add additional newline before allure report link

### DIFF
--- a/lib/allure_report_publisher/lib/providers/_base.rb
+++ b/lib/allure_report_publisher/lib/providers/_base.rb
@@ -49,7 +49,7 @@ module Publisher
         reported = pr_description.match?(DESCRIPTION_PATTERN)
         return update_pr_description(pr_description.gsub(DESCRIPTION_PATTERN, description_template).strip) if reported
 
-        update_pr_description("#{pr_description}\n#{description_template}".strip)
+        update_pr_description("#{pr_description}\n\n#{description_template}".strip)
       end
 
       private

--- a/spec/allure_report_publisher/lib/providers/github_spec.rb
+++ b/spec/allure_report_publisher/lib/providers/github_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Publisher::Providers::Github do
           1,
           body: <<~DESC.strip
             #{pr_description}
+
             <!-- allure -->
             ---
             📝 [Latest allure report](#{report_url})

--- a/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
+++ b/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Publisher::Providers::Gitlab do
           env[:CI_MERGE_REQUEST_IID],
           description: <<~DESC.strip
             #{mr_description}
+
             <!-- allure -->
             ---
             📝 [Latest allure report](#{report_url})


### PR DESCRIPTION
Fixes incorrect rendering in some cases like dependabot PR's
<!-- allure -->
---
📝 [Latest allure report](http://allure-reports-andrcuns.s3.amazonaws.com/allure-report-publisher/refs/pull/53/merge/807004294/index.html)
<!-- allurestop -->