### PR TITLE
Fix urls added to PR description or comment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           BUNDLE_WITHOUT: development
       - name: Rubocop
-        run: bundle exec rubocop --color
+        run: cat $GITHUB_EVENT_PATH && bundle exec rubocop --color
 
   rspec:
     runs-on: ubuntu-20.04

--- a/lib/allure_report_publisher/lib/providers/github.rb
+++ b/lib/allure_report_publisher/lib/providers/github.rb
@@ -48,6 +48,13 @@ module Publisher
         end
       end
 
+      # Github event
+      #
+      # @return [Hash]
+      def github_event
+        @github_event ||= JSON.parse(File.read(ENV["GITHUB_EVENT_PATH"]), symbolize_names: true)
+      end
+
       # Pull request description
       #
       # @return [String]
@@ -73,7 +80,7 @@ module Publisher
       #
       # @return [Integer]
       def pr_id
-        @pr_id ||= JSON.parse(File.read(ENV["GITHUB_EVENT_PATH"]))["number"]
+        @pr_id ||= github_event[:number]
       end
 
       # Server url
@@ -108,7 +115,7 @@ module Publisher
       #
       # @return [String]
       def sha_url
-        sha = ENV["GITHUB_SHA"]
+        sha = github_event.dig(:pull_request, :head, :sha)
 
         "[#{sha}](#{server_url}/#{repository}/pull/#{pr_id}/commits/#{sha})"
       end

--- a/lib/allure_report_publisher/lib/providers/gitlab.rb
+++ b/lib/allure_report_publisher/lib/providers/gitlab.rb
@@ -110,8 +110,9 @@ module Publisher
       # @return [String]
       def sha_url
         sha = ENV["CI_COMMIT_SHA"]
+        short_sha = ENV["CI_COMMIT_SHORT_SHA"]
 
-        "[#{sha}](#{server_url}/#{project}/-/tree/#{sha})"
+        "[#{short_sha}](#{server_url}/#{project}/-/tree/#{sha})"
       end
     end
   end

--- a/spec/allure_report_publisher/lib/providers/github_spec.rb
+++ b/spec/allure_report_publisher/lib/providers/github_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe Publisher::Providers::Github do
   let(:auth_token) { "token" }
   let(:event_name) { "pull_request" }
   let(:update_pr) { "description" }
+  let(:sha) { "e1de5e18c3af8" }
   let(:sha_url) do
-    "[#{env[:GITHUB_SHA]}](#{env[:GITHUB_SERVER_URL]}/#{env[:GITHUB_REPOSITORY]}/pull/1/commits/#{env[:GITHUB_SHA]})"
+    "[#{sha}](#{env[:GITHUB_SERVER_URL]}/#{env[:GITHUB_REPOSITORY]}/pull/1/commits/#{sha})"
   end
 
   let(:env) do
@@ -20,8 +21,7 @@ RSpec.describe Publisher::Providers::Github do
       GITHUB_API_URL: "https://api.github.com",
       GITHUB_EVENT_PATH: "spec/fixture/workflow_event.json",
       GITHUB_AUTH_TOKEN: auth_token,
-      GITHUB_EVENT_NAME: event_name,
-      GITHUB_SHA: "sha"
+      GITHUB_EVENT_NAME: event_name
     }.compact
   end
 

--- a/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
+++ b/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe Publisher::Providers::Gitlab do
   let(:auth_token) { "token" }
   let(:event_name) { "merge_request_event" }
   let(:update_pr) { "description" }
+  let(:sha) { "e1de5e18c3af8skjdhfksjdhjk" }
+  let(:short_sha) { "e1de5e18c3af8" }
   let(:sha_url) do
-    "[#{env[:CI_COMMIT_SHA]}](#{env[:CI_SERVER_URL]}/#{env[:CI_PROJECT_PATH]}/-/tree/#{env[:CI_COMMIT_SHA]})"
+    "[#{short_sha}](#{env[:CI_SERVER_URL]}/#{env[:CI_PROJECT_PATH]}/-/tree/#{sha})"
   end
 
   let(:env) do
@@ -21,7 +23,8 @@ RSpec.describe Publisher::Providers::Gitlab do
       CI_PIPELINE_URL: "https://gitlab.com/pipeline/url",
       CI_PIPELINE_SOURCE: event_name,
       GITLAB_AUTH_TOKEN: auth_token,
-      CI_COMMIT_SHA: "sha"
+      CI_COMMIT_SHA: sha,
+      CI_COMMIT_SHORT_SHA: short_sha
     }.compact
   end
 

--- a/spec/fixture/workflow_event.json
+++ b/spec/fixture/workflow_event.json
@@ -1,3 +1,8 @@
 {
-  "number": 1
+  "number": 1,
+  "pull_request": {
+    "head": {
+      "sha": "e1de5e18c3af8"
+    }
+  }
 }


### PR DESCRIPTION
<!-- allure -->
---
# Allure report
`allure-report-publisher` generated allure report for [d8ad50fd2f9a41ec284a219afe536c870d0f77f4](https://github.com/andrcuns/allure-report-publisher/pull/87/commits/d8ad50fd2f9a41ec284a219afe536c870d0f77f4)!

**rspec**: 📝 [allure report](http://allure-reports-andrcuns.s3.amazonaws.com/allure-report-publisher/refs/pull/87/merge/859774154/index.html)
<!-- allurestop -->