### PR TITLE
Move write executor info method out of provider class

### DIFF
--- a/lib/allure_report_publisher/lib/providers/_provider.rb
+++ b/lib/allure_report_publisher/lib/providers/_provider.rb
@@ -13,11 +13,9 @@ module Publisher
     # Base class for CI executor info
     #
     class Provider
-      EXECUTOR_JSON = "executor.json".freeze
       DESCRIPTION_PATTERN = /<!-- allure -->[\s\S]+<!-- allurestop -->/.freeze
 
-      def initialize(results_path:, report_url:, update_pr:)
-        @results_path = results_path
+      def initialize(report_url:, update_pr:)
         @report_url = report_url
         @update_pr = update_pr
       end
@@ -30,16 +28,14 @@ module Publisher
       def self.run_id
         raise("Not implemented!")
       end
-      # :nocov:
 
-      # Write executor info file
+      # Get executor info
       #
-      # @return [void]
-      def write_executor_info
-        File.open("#{results_path}/#{EXECUTOR_JSON}", "w") do |file|
-          file.write(executor_info.to_json)
-        end
+      # @return [Hash]
+      def executor_info
+        raise("Not implemented!")
       end
+      # :nocov:
 
       # Add report url to pull request description
       #
@@ -62,14 +58,7 @@ module Publisher
 
       private
 
-      attr_reader :results_path, :report_url, :update_pr
-
-      # Get executor info
-      #
-      # @return [Hash]
-      def executor_info
-        raise("Not implemented!")
-      end
+      attr_reader :report_url, :update_pr
 
       # Current pull request description
       #

--- a/lib/allure_report_publisher/lib/providers/github.rb
+++ b/lib/allure_report_publisher/lib/providers/github.rb
@@ -19,8 +19,6 @@ module Publisher
         ENV["GITHUB_EVENT_NAME"] == "pull_request"
       end
 
-      private
-
       # Executor info
       #
       # @return [Hash]
@@ -36,6 +34,8 @@ module Publisher
           buildName: build_name
         }
       end
+
+      private
 
       # Github api client
       #

--- a/lib/allure_report_publisher/lib/providers/gitlab.rb
+++ b/lib/allure_report_publisher/lib/providers/gitlab.rb
@@ -35,6 +35,8 @@ module Publisher
         }
       end
 
+      private
+
       # Current pull request description
       #
       # @return [String]

--- a/lib/allure_report_publisher/lib/uploaders/_uploader.rb
+++ b/lib/allure_report_publisher/lib/uploaders/_uploader.rb
@@ -7,6 +7,7 @@ module Publisher
     class Uploader
       include Helpers
 
+      EXECUTOR_JSON = "executor.json".freeze
       HISTORY = [
         "categories-trend.json",
         "duration-trend.json",
@@ -147,7 +148,9 @@ module Publisher
       def add_executor_info
         return unless ci_provider
 
-        ci_provider.write_executor_info
+        File.open("#{results_path}/#{EXECUTOR_JSON}", "w") do |file|
+          file.write(ci_provider.executor_info.to_json)
+        end
       end
 
       # Run upload commands
@@ -172,7 +175,7 @@ module Publisher
       def ci_provider
         return @ci_provider if defined?(@ci_provider)
 
-        @ci_provider = Providers.provider&.new(results_path: results_path, report_url: report_url, update_pr: update_pr)
+        @ci_provider = Providers.provider&.new(report_url: report_url, update_pr: update_pr)
       end
 
       # Fetch allure report history

--- a/spec/allure_report_publisher/lib/providers/github_spec.rb
+++ b/spec/allure_report_publisher/lib/providers/github_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe Publisher::Providers::Github do
-  subject(:provider) { described_class.new(results_path: results_path, report_url: report_url, update_pr: update_pr) }
+  subject(:provider) { described_class.new(report_url: report_url, update_pr: update_pr) }
 
-  let(:results_path) { Dir.mktmpdir("allure-results", "tmp") }
   let(:report_url) { "https://report.com" }
   let(:auth_token) { "token" }
   let(:event_name) { "pull_request" }
@@ -29,11 +28,9 @@ RSpec.describe Publisher::Providers::Github do
     ClimateControl.modify(env) { example.run }
   end
 
-  context "when adding executor info" do
-    it "creates correct executor.json file" do
-      provider.write_executor_info
-
-      expect(JSON.parse(File.read("#{results_path}/executor.json"), symbolize_names: true)).to eq(
+  context "with any context" do
+    it "returns correct executor info" do
+      expect(provider.executor_info).to eq(
         {
           name: "Github",
           type: "github",
@@ -145,7 +142,7 @@ RSpec.describe Publisher::Providers::Github do
     end
   end
 
-  context "without pr ci context" do
+  context "without pr context" do
     let(:event_name) { "push" }
 
     it "skips adding allure link to pr with not a pr message" do

--- a/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
+++ b/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe Publisher::Providers::Gitlab do
-  subject(:provider) { described_class.new(results_path: results_path, report_url: report_url, update_pr: update_pr) }
+  subject(:provider) { described_class.new(report_url: report_url, update_pr: update_pr) }
 
-  let(:results_path) { Dir.mktmpdir("allure-results", "tmp") }
   let(:report_url) { "https://report.com" }
   let(:auth_token) { "token" }
   let(:event_name) { "merge_request_event" }
@@ -34,11 +33,9 @@ RSpec.describe Publisher::Providers::Gitlab do
     ClimateControl.modify(env) { example.run }
   end
 
-  context "when adding executor info" do
-    it "creates correct executor.json file" do
-      provider.write_executor_info
-
-      expect(JSON.parse(File.read("#{results_path}/executor.json"), symbolize_names: true)).to eq(
+  context "with any execution context" do
+    it "returns correct executor info" do
+      expect(provider.executor_info).to eq(
         {
           name: "Gitlab",
           type: "gitlab",

--- a/spec/allure_report_publisher/lib/uploaders/common_uploader.rb
+++ b/spec/allure_report_publisher/lib/uploaders/common_uploader.rb
@@ -2,11 +2,13 @@ RSpec.shared_context("with uploader") do
   include_context "with mock helper"
 
   let(:report_generator) { instance_double("Publisher::ReportGenerator", generate: nil) }
+  let(:executor_file) { instance_double("File", write: nil) }
   let(:results_glob) { "spec/fixture/fake_results/*" }
   let(:bucket_name) { "bucket" }
   let(:prefix) { "project" }
   let(:ci_provider) { nil }
   let(:run_id) { 1 }
+  let(:executor_info) { { name: "Github" } }
   let(:history_files) do
     [
       "categories-trend.json",
@@ -26,14 +28,14 @@ RSpec.shared_context("with uploader") do
     }
   end
 
-  let(:results_dir) { "spec/fixture/fake_results" }
-  let(:report_dir) { "spec/fixture/fake_report" }
+  let(:results_path) { "spec/fixture/fake_results" }
+  let(:report_path) { "spec/fixture/fake_report" }
 
   before do
     allow(Publisher::Providers).to receive(:provider) { ci_provider }
     allow(Publisher::ReportGenerator).to receive(:new) { report_generator }
 
-    allow(Dir).to receive(:mktmpdir).with("allure-results") { results_dir }
-    allow(Dir).to receive(:mktmpdir).with("allure-report") { report_dir }
+    allow(Dir).to receive(:mktmpdir).with("allure-results") { results_path }
+    allow(Dir).to receive(:mktmpdir).with("allure-report") { report_path }
   end
 end


### PR DESCRIPTION
<!-- allure -->
---
# Allure report
`allure-report-publisher` generated allure report for [81647b64bccb1c9532db23669fd8ade5296010aa](https://github.com/andrcuns/allure-report-publisher/pull/89/commits/81647b64bccb1c9532db23669fd8ade5296010aa)!

**rspec**: 📝 [allure report](http://allure-reports-andrcuns.s3.amazonaws.com/allure-report-publisher/refs/pull/89/merge/860481869/index.html)
<!-- allurestop -->