### PR TITLE
Add custom parameters for Gitlab CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ It is possible to update pull requests with urls to published reports.
 
 - `--update-pr=(comment|description)`: post report urls in pr description or as a comment
 
+Example:
+
+---
+
+`# Allure report`
+
+`allure-report-publisher` generated test report for [1b756f48](https://github.com/andrcuns/allure-report-publisher/commit/HEAD)!
+
+**rspec**: 📝 [test report](https://storage.googleapis.com/allure-test-reports/allure-report-publisher/refs/heads/main/index.html)
+
+---
+
 ## Github Actions
 
 Additional configuration is done via environment variables

--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ Following environment variables can override default CI values:
 
 In case merge request triggers a downstream pipeline yet you want to update original merge request, overriding following environment variables might be useful:
 
-- `ALLURE_PROJECT`: overrides default `CI_PROJECT_PATH` value
-- `ALLURE_MR_IID`: overrides default `CI_MERGE_REQUEST_IID` value
-- `ALLURE_SHA`: overrides default `CI_MERGE_REQUEST_SOURCE_BRANCH_SHA` or `CI_COMMIT_SHA` values
+- `ALLURE_PROJECT_PATH`: overrides default `CI_PROJECT_PATH` value
+- `ALLURE_MERGE_REQUEST_IID`: overrides default `CI_MERGE_REQUEST_IID` value
+- `ALLURE_COMMIT_SHA`: overrides default `CI_MERGE_REQUEST_SOURCE_BRANCH_SHA` or `CI_COMMIT_SHA` values
 
 # Development
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# allure-report-publisher
+
 [![Gem Version](https://img.shields.io/gem/v/allure-report-publisher?color=red)](https://rubygems.org/gems/allure-report-publisher)
 [![Gem Pulls](https://img.shields.io/gem/dt/allure-report-publisher)](https://rubygems.org/gems/allure-report-publisher)
 [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/andrcuns/allure-report-publisher?color=blue&label=docker&sort=semver)](https://hub.docker.com/r/andrcuns/allure-report-publisher)
@@ -7,31 +9,25 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/210eaa4f74588fb08313/maintainability)](https://codeclimate.com/github/andrcuns/allure-report-publisher/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/210eaa4f74588fb08313/test_coverage)](https://codeclimate.com/github/andrcuns/allure-report-publisher/test_coverage)
 
-# allure-report-publisher
-
 Upload your report to a file storage of your choice.
 
 ![Demo](demo.gif)
 
-## Installation
+# Installation
 
-### Rubygems
+## Rubygems
 
 ```shell
 gem install allure-report-uploader
 ```
 
-### Docker
+## Docker
 
 ```shell
 docker pull andrcuns/allure-report-publisher:latest
 ```
 
-## Usage
-
-allure-report-publisher will automatically detect if used in CI environment and add relevant executor info and history
-
-- `--update-pr=(comment|description)`: requires `GITHUB_AUTH_TOKEN` or `GITLAB_AUTH_TOKEN` in order to update pull request with links to allure reports
+# Usage
 
 ```shell
 $ (allure-report-publisher|docker run --rm andrcuns/allure-report-publisher:latest) upload --help
@@ -61,11 +57,15 @@ Examples:
   allure-report-publisher upload gcs --results-glob='path/to/allure-result/**/*' --bucket=my-bucket --prefix=my-project/prs
 ```
 
-### AWS S3
+# Storage providers
+
+Multiple cloud storage providers are supported
+
+## AWS S3
 
 Requires environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` or credentials file `~/.aws/credentials`
 
-### Google Cloud Storage
+## Google Cloud Storage
 
 Requires on of the following environment variables.
 
@@ -86,20 +86,65 @@ credentials.json contents:
 - `GOOGLE_CLOUD_KEYFILE_JSON`
 - `GCLOUD_KEYFILE_JSON`
 
-## Development
+# CI
+
+`allure-report-publisher` will automatically detect if used in CI environment and add relevant executor info and history.
+
+Following CI providers are supported:
+
+- Github Actions
+- Gitlab CI
+
+## Pull requests
+
+It is possible to update pull requests with urls to published reports.
+
+- `--update-pr=(comment|description)`: post report urls in pr description or as a comment
+
+## Github Actions
+
+Additional configuration is done via environment variables
+
+Authentication for PR updates:
+
+- `GITHUB_AUTH_TOKEN`: github auth token with api access
+
+Following environment variables can override default CI values:
+
+- `ALLURE_JOB_NAME`: overrides default `GITHUB_JOB` value which is used as name for report url section
+
+## Gitlab CI
+
+Additional configuration is done via environment variables
+
+Authentication for MR updates:
+
+- `GITLAB_AUTH_TOKEN`: gitlab access token with api access
+
+Following environment variables can override default CI values:
+
+- `ALLURE_JOB_NAME`: overrides default `CI_JOB_NAME` value which is used as name for report url section
+
+In case merge request triggers a downstream pipeline yet you want to update original merge request, overriding following environment variables might be useful:
+
+- `ALLURE_PROJECT`: overrides default `CI_PROJECT_PATH` value
+- `ALLURE_MR_IID`: overrides default `CI_MERGE_REQUEST_IID` value
+- `ALLURE_SHA`: overrides default `CI_MERGE_REQUEST_SOURCE_BRANCH_SHA` or `CI_COMMIT_SHA` values
+
+# Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 
-## Contributing
+# Contributing
 
 Bug reports and pull requests are welcome on GitHub at <https://github.com/andrcuns/allure-report-publisher>. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/andrcuns/allure-report-publisher/blob/main/CODE_OF_CONDUCT.md).
 
-## License
+# License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
 
-## Code of Conduct
+# Code of Conduct
 
 Everyone interacting in the allure-report-publisher project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/andrcuns/allure-report-publisher/blob/main/CODE_OF_CONDUCT.md).

--- a/lib/allure_report_publisher/lib/providers/gitlab.rb
+++ b/lib/allure_report_publisher/lib/providers/gitlab.rb
@@ -87,21 +87,21 @@ module Publisher
       #
       # @return [String]
       def allure_project
-        @allure_project ||= ENV["ALLURE_PROJECT"]
+        @allure_project ||= ENV["ALLURE_PROJECT_PATH"]
       end
 
       # Custom mr iid name
       #
       # @return [String]
       def allure_mr_iid
-        @allure_mr_iid ||= ENV["ALLURE_MR_IID"]
+        @allure_mr_iid ||= ENV["ALLURE_MERGE_REQUEST_IID"]
       end
 
       # Custom sha
       #
       # @return [String]
       def allure_sha
-        @allure_sha ||= ENV["ALLURE_SHA"]
+        @allure_sha ||= ENV["ALLURE_COMMIT_SHA"]
       end
 
       # Gitlab project path

--- a/lib/allure_report_publisher/lib/providers/gitlab.rb
+++ b/lib/allure_report_publisher/lib/providers/gitlab.rb
@@ -16,7 +16,7 @@ module Publisher
       #
       # @return [Boolean]
       def pr?
-        ENV["CI_PIPELINE_SOURCE"] == "merge_request_event"
+        (allure_project && allure_mr_iid) || ENV["CI_PIPELINE_SOURCE"] == "merge_request_event"
       end
 
       # Get executor info
@@ -83,11 +83,39 @@ module Publisher
         end
       end
 
+      # Custom repository name
+      #
+      # @return [String]
+      def allure_project
+        @allure_project ||= ENV["ALLURE_PROJECT"]
+      end
+
+      # Custom mr iid name
+      #
+      # @return [String]
+      def allure_mr_iid
+        @allure_mr_iid ||= ENV["ALLURE_MR_IID"]
+      end
+
+      # Custom sha
+      #
+      # @return [String]
+      def allure_sha
+        @allure_sha ||= ENV["ALLURE_SHA"]
+      end
+
+      # Gitlab project path
+      #
+      # @return [String]
+      def project
+        @project ||= allure_project || ENV["CI_PROJECT_PATH"]
+      end
+
       # Merge request iid
       #
       # @return [Integer]
       def mr_iid
-        @mr_iid ||= ENV["CI_MERGE_REQUEST_IID"]
+        @mr_iid ||= allure_mr_iid || ENV["CI_MERGE_REQUEST_IID"]
       end
 
       # Server url
@@ -111,18 +139,11 @@ module Publisher
         @build_name ||= ENV[ALLURE_JOB_NAME] || ENV["CI_JOB_NAME"]
       end
 
-      # Gitlab repository
-      #
-      # @return [String]
-      def project
-        @project ||= ENV["CI_PROJECT_PATH"]
-      end
-
       # Commit sha url
       #
       # @return [String]
       def sha_url
-        sha = ENV["CI_MERGE_REQUEST_SOURCE_BRANCH_SHA"] || ENV["CI_COMMIT_SHA"]
+        sha = allure_sha || ENV["CI_MERGE_REQUEST_SOURCE_BRANCH_SHA"] || ENV["CI_COMMIT_SHA"]
         short_sha = sha[0..7]
 
         "[#{short_sha}](#{server_url}/#{project}/-/merge_requests/#{mr_iid}/diffs?commit_id=#{sha})"

--- a/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
+++ b/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe Publisher::Providers::Gitlab do
       CI_PIPELINE_SOURCE: event_name,
       CI_MERGE_REQUEST_SOURCE_BRANCH_SHA: sha,
       GITLAB_AUTH_TOKEN: auth_token,
-      ALLURE_PROJECT: custom_project,
-      ALLURE_MR_IID: custom_mr_id
+      ALLURE_PROJECT_PATH: custom_project,
+      ALLURE_MERGE_REQUEST_IID: custom_mr_id
     }.compact
   end
 


### PR DESCRIPTION
Add ability to override parameters via environment variables for Gitlab CI in case of downstream pipelines:

* `ALLURE_PROJECT_PATH`
* `ALLURE_MERGE_REQUEST_IID`
* `ALLURE_COMMIT_SHA`