### PR TITLE
Fix --color option for initial errors

### DIFF
--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -42,9 +42,10 @@ module Publisher
       ]
 
       def call(**args)
+        Helpers.pastel(force_color: args[:color] || nil)
+
         validate_args(args)
         validate_result_files(args[:results_glob], args[:ignore_missing_results])
-        Helpers.pastel(force_color: args[:color] || nil)
 
         uploader = uploaders(args[:type]).new(**args.slice(:results_glob, :bucket, :prefix, :copy_latest, :update_pr))
 


### PR DESCRIPTION
Take in to account `--color` option for initial errors of missing args or allure-results