### PR TITLE
Add support for custom s3 endpoint and force_path_style option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Multiple cloud storage providers are supported
 
 Requires environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` or credentials file `~/.aws/credentials`
 
+Additional configuration:
+
+- `AWS_REGION`: configure s3 region, default: `us-east-1`
+- `AWS_FORCE_PATH_STYLE`: when set to true, the bucket name is always left in the request URI and never moved to the host as a sub-domain, default: `false`
+- `AWS_ENDPOINT`: custom s3 endpoint when used with other s3 compatible storage
+
 ## Google Cloud Storage
 
 Requires on of the following environment variables.

--- a/lib/allure_report_publisher/lib/uploaders/s3.rb
+++ b/lib/allure_report_publisher/lib/uploaders/s3.rb
@@ -11,13 +11,21 @@ module Publisher
       #
       # @return [Aws::S3::Client]
       def client
-        @client ||= Aws::S3::Client.new(region: ENV["AWS_REGION"] || "us-east-1")
+        @client ||= Aws::S3::Client.new(client_args)
       rescue Aws::Sigv4::Errors::MissingCredentialsError
         raise(<<~MSG.strip)
           missing aws credentials, provide credentials with one of the following options:
             - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables
             - ~/.aws/credentials file
         MSG
+      end
+
+      def client_args
+        @client_args ||= {
+          region: ENV["AWS_REGION"] || "us-east-1",
+          force_path_style: ENV["AWS_FORCE_PATH_STYLE"] == "true",
+          endpoint: ENV["AWS_ENDPOINT"]
+        }.compact
       end
 
       # Report url


### PR DESCRIPTION
Allows to configure custom s3 endpoint to use with other s3 compatible storage like minio