### PR TITLE
Publish report only when secrets are available in the workflow run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
   publish-report:
     runs-on: ubuntu-22.04
     needs: rspec
-    if: always()
+    if: github.actor == 'andrcuns'
     steps:
       -
         name: Checkout


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/364/merge/3085468698/index.html) for [9352f25a](https://github.com/andrcuns/allure-report-publisher/pull/364/commits/9352f25ae33499de01e77521644d33ebbe856979)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| helpers   | 41     | 0      | 0       | 0     | 41    | ✅     |
| uploaders | 17     | 0      | 0       | 0     | 17    | ✅     |
| providers | 16     | 0      | 0       | 0     | 16    | ✅     |
| generator | 3      | 0      | 0       | 0     | 3     | ✅     |
| cli       | 1      | 0      | 0       | 0     | 1     | ✅     |
| commands  | 19     | 0      | 0       | 0     | 19    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 97     | 0      | 0       | 0     | 97    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->