### PR TITLE
Report generation performance improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
             -e ALLURE_JOB_NAME="rspec" \
             publisher:latest \
             upload gcs \
-              --results-glob="/workspace/reports/allure-results/*" \
+              --results-glob="/workspace/reports/allure-results" \
               --bucket="allure-test-reports" \
               --prefix="allure-report-publisher/$GITHUB_REF" \
               --update-pr="actions" \
@@ -136,7 +136,7 @@ jobs:
             -e ALLURE_JOB_NAME="rspec" \
             publisher:latest \
             upload s3 \
-              --results-glob="/workspace/reports/allure-results/*" \
+              --results-glob="/workspace/reports/allure-results" \
               --bucket="allure-tests-reports" \
               --prefix="allure-report-publisher/$GITHUB_REF" \
               --update-pr="description" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
   publish-report:
     runs-on: ubuntu-22.04
     needs: rspec
-    if: github.actor == 'andrcuns'
+    if: github.actor == 'andrcuns' && always()
     steps:
       -
         name: Checkout

--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -14,7 +14,7 @@ module Publisher
                desc: "Cloud storage type"
 
       option :results_glob,
-             desc: "Allure results files glob. Required: true"
+             desc: "Glob pattern to return allure results directories. Required: true"
       option :bucket,
              desc: "Bucket name. Required: true"
       option :prefix,
@@ -57,8 +57,8 @@ module Publisher
              desc: "Ignore missing allure results"
 
       example [
-        "s3 --results-glob='path/to/allure-result/**/*' --bucket=my-bucket",
-        "gcs --results-glob='path/to/allure-result/**/*' --bucket=my-bucket --prefix=my-project/prs"
+        "s3 --results-glob='path/to/allure-results' --bucket=my-bucket",
+        "gcs --results-glob='paths/to/**/allure-results' --bucket=my-bucket --prefix=my-project/prs"
       ]
 
       def call(**args)

--- a/lib/allure_report_publisher/lib/report_generator.rb
+++ b/lib/allure_report_publisher/lib/report_generator.rb
@@ -18,15 +18,14 @@ module Publisher
     #
     # @return [void]
     def generate
-      aggregate_results
       generate_report
     end
 
-    # Aggregated results directory
+    # Common path for history and executor info
     #
     # @return [String]
-    def results_path
-      @results_path ||= Dir.mktmpdir("allure-results")
+    def common_info_path
+      @common_info_path ||= Dir.mktmpdir("allure-results")
     end
 
     # Allure report directory
@@ -40,14 +39,16 @@ module Publisher
 
     attr_reader :results_glob
 
-    # Copy all results files to results directory
+    # Return all allure results paths from glob
     #
-    # @return [void]
-    def aggregate_results
-      results = Dir.glob(results_glob)
-      raise(NoAllureResultsError, "Missing allure results") if results.empty?
+    # @return [String]
+    def result_paths
+      @result_paths ||= begin
+        paths = Dir.glob(results_glob)
+        raise(NoAllureResultsError, "Missing allure results") if paths.empty?
 
-      FileUtils.cp(results, results_path)
+        paths.join(" ")
+      end
     end
 
     # Generate allure report
@@ -55,7 +56,7 @@ module Publisher
     # @return [void]
     def generate_report
       out, _err, status = Open3.capture3(
-        "allure generate --clean --output #{report_path} #{results_path}"
+        "allure generate --clean --output #{report_path} #{common_info_path} #{result_paths}"
       )
       raise(AllureError, out) unless status.success?
     end

--- a/lib/allure_report_publisher/lib/uploaders/_uploader.rb
+++ b/lib/allure_report_publisher/lib/uploaders/_uploader.rb
@@ -104,7 +104,7 @@ module Publisher
                   :collapse_summary,
                   :summary_table_type
 
-      def_delegators :report_generator, :results_path, :report_path
+      def_delegators :report_generator, :common_info_path, :report_path
 
       # :nocov:
 
@@ -224,7 +224,7 @@ module Publisher
       def add_executor_info
         return unless ci_provider
 
-        File.write("#{results_path}/#{EXECUTOR_JSON}", ci_provider.executor_info.to_json)
+        File.write("#{common_info_path}/#{EXECUTOR_JSON}", ci_provider.executor_info.to_json)
       end
 
       # Run upload commands
@@ -240,7 +240,7 @@ module Publisher
       #
       # @return [void]
       def create_history_dir
-        FileUtils.mkdir_p(path(results_path, "history"))
+        FileUtils.mkdir_p(path(common_info_path, "history"))
       end
     end
   end

--- a/lib/allure_report_publisher/lib/uploaders/gcs.rb
+++ b/lib/allure_report_publisher/lib/uploaders/gcs.rb
@@ -43,7 +43,7 @@ module Publisher
           file = bucket.file(key(prefix, "history", file_name))
           raise(HistoryNotFoundError, "Allure history from previous runs not found!") unless file
 
-          file.download(path(results_path, "history", file_name))
+          file.download(path(common_info_path, "history", file_name))
         end
       end
 

--- a/lib/allure_report_publisher/lib/uploaders/s3.rb
+++ b/lib/allure_report_publisher/lib/uploaders/s3.rb
@@ -49,7 +49,7 @@ module Publisher
       def download_history
         HISTORY.each do |file|
           client.get_object(
-            response_target: path(results_path, "history", file),
+            response_target: path(common_info_path, "history", file),
             key: key(prefix, "history", file),
             bucket: bucket_name
           )

--- a/spec/allure_report_publisher/lib/report_generator_spec.rb
+++ b/spec/allure_report_publisher/lib/report_generator_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Publisher::ReportGenerator, epic: "generator" do
 
   let(:capture_status) { instance_double(Process::Status, success?: status) }
 
-  let(:results_glob) { "spec/fixture/fake_results/*" }
+  let(:results_glob) { "spec/fixture/fake_results" }
   let(:results_dir) { "/results_dir" }
   let(:report_dir) { "/report_dir" }
   let(:status) { true }
@@ -13,7 +13,6 @@ RSpec.describe Publisher::ReportGenerator, epic: "generator" do
   before do
     allow(Dir).to receive(:mktmpdir).with("allure-results") { results_dir }
     allow(Dir).to receive(:mktmpdir).with("allure-report") { report_dir }
-    allow(FileUtils).to receive(:cp)
     allow(Open3).to receive(:capture3) { ["Allure output", "", capture_status] }
   end
 
@@ -22,8 +21,9 @@ RSpec.describe Publisher::ReportGenerator, epic: "generator" do
       aggregate_failures do
         report_generator.generate
 
-        expect(FileUtils).to have_received(:cp).with(Dir.glob(results_glob), results_dir)
-        expect(Open3).to have_received(:capture3).with("allure generate --clean --output #{report_dir} #{results_dir}")
+        expect(Open3).to have_received(:capture3).with(
+          "allure generate --clean --output #{report_dir} #{results_dir} #{results_glob}"
+        )
       end
     end
   end

--- a/spec/allure_report_publisher/lib/uploaders/common_uploader.rb
+++ b/spec/allure_report_publisher/lib/uploaders/common_uploader.rb
@@ -5,7 +5,7 @@ RSpec.shared_context "with uploader" do
     instance_double(
       Publisher::ReportGenerator,
       generate: nil,
-      results_path: results_path,
+      common_info_path: common_info_path,
       report_path: report_path
     )
   end
@@ -37,7 +37,7 @@ RSpec.shared_context "with uploader" do
     }
   end
 
-  let(:results_path) { "spec/fixture/fake_results" }
+  let(:common_info_path) { "spec/fixture/fake_results" }
   let(:report_path) { "spec/fixture/fake_report" }
 
   before do

--- a/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
       aggregate_failures do
         history_files.each do |f|
           expect(bucket).to have_received(:file).with("#{prefix}/history/#{f}")
-          expect(file).to have_received(:download).with("#{results_path}/history/#{f}")
+          expect(file).to have_received(:download).with("#{common_info_path}/history/#{f}")
         end
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
       aggregate_failures do
         history_files.each do |f|
           expect(bucket).to have_received(:file).with("#{prefix}/history/#{f}")
-          expect(file).to have_received(:download).with("#{results_path}/history/#{f}")
+          expect(file).to have_received(:download).with("#{common_info_path}/history/#{f}")
         end
 
         expect(bucket).to have_received(:create_file).with(*history, cache_control)
@@ -87,7 +87,7 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
 
     it "adds executor info" do
       described_class.new(**args).execute
-      expect(File).to have_received(:write).with("#{results_path}/executor.json", executor_info.to_json)
+      expect(File).to have_received(:write).with("#{common_info_path}/executor.json", executor_info.to_json)
     end
 
     it "updates pr description with allure report link" do

--- a/spec/allure_report_publisher/lib/uploaders/s3_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/s3_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Publisher::Uploaders::S3, epic: "uploaders" do
       aggregate_failures do
         history_files.each do |file|
           expect(s3_client).to have_received(:get_object).with(
-            response_target: "#{results_path}/history/#{file}",
+            response_target: "#{common_info_path}/history/#{file}",
             key: "#{prefix}/history/#{file}",
             bucket: bucket_name
           )
@@ -141,7 +141,7 @@ RSpec.describe Publisher::Uploaders::S3, epic: "uploaders" do
 
     it "adds executor info" do
       described_class.new(**args).execute
-      expect(File).to have_received(:write).with("#{results_path}/executor.json", executor_info.to_json)
+      expect(File).to have_received(:write).with("#{common_info_path}/executor.json", executor_info.to_json)
     end
 
     it "updates pr description with allure report link" do


### PR DESCRIPTION
⚠️ Breaking change ⚠️ 

* Removes filesystem copy operation which in case of large reports can significantly slow down report generation. 

This changes `--results-glob` behaviour. It now must return a list of folders containing allure results instead of returning list of files.

Closes: https://github.com/andrcuns/allure-report-publisher/issues/355

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/367/merge/3119217475/index.html) for [b8769b2a](https://github.com/andrcuns/allure-report-publisher/pull/367/commits/b8769b2a29f5f46426e3249e96e678f8d8d3664b)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| commands  | 19     | 0      | 0       | 0     | 19    | ✅     |
| uploaders | 17     | 0      | 0       | 0     | 17    | ✅     |
| helpers   | 41     | 0      | 0       | 0     | 41    | ✅     |
| providers | 16     | 0      | 0       | 0     | 16    | ✅     |
| generator | 3      | 0      | 0       | 0     | 3     | ✅     |
| cli       | 1      | 0      | 0       | 0     | 1     | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 97     | 0      | 0       | 0     | 97    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->