### PR TITLE
Run e2e publish as matrix job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: rspec
     if: github.actor == 'andrcuns' && always()
+    name: Publish report to ${{ matrix.provider }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,18 @@ jobs:
     runs-on: ubuntu-22.04
     needs: rspec
     if: github.actor == 'andrcuns' && always()
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - provider: gcs
+            bucket: allure-test-reports
+            table: ascii
+            results: actions
+          - provider: s3
+            bucket: allure-tests-reports
+            table: markdown
+            results: description
     steps:
       -
         name: Checkout
@@ -80,9 +92,11 @@ jobs:
           name: allure-reports
           path: reports/allure-results
       -
-        name: Publish allure report to GCS
+        name: Publish allure report
         env:
           GOOGLE_CLOUD_CREDENTIALS_JSON: ${{ secrets.GOOGLE_CLOUD_CREDENTIALS_JSON }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           docker run --rm \
@@ -100,47 +114,16 @@ jobs:
             -e GITHUB_SHA="$GITHUB_SHA" \
             -e GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" \
             -e GOOGLE_CLOUD_CREDENTIALS_JSON="$GOOGLE_CLOUD_CREDENTIALS_JSON" \
-            -e ALLURE_JOB_NAME="rspec" \
-            publisher:latest \
-            upload gcs \
-              --results-glob="/workspace/reports/allure-results" \
-              --bucket="allure-test-reports" \
-              --prefix="allure-report-publisher/$GITHUB_REF" \
-              --update-pr="actions" \
-              --summary="behaviors" \
-              --summary-table-type="markdown" \
-              --copy-latest \
-              --color
-      -
-        name: Publish allure report to S3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker run --rm \
-            -v "$(pwd)":/workspace \
-            -v "$GITHUB_EVENT_PATH:$GITHUB_EVENT_PATH" \
-            -e GITHUB_WORKFLOW="$GITHUB_WORKFLOW" \
-            -e GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME" \
-            -e GITHUB_EVENT_PATH="$GITHUB_EVENT_PATH" \
-            -e GITHUB_SERVER_URL="$GITHUB_SERVER_URL" \
-            -e GITHUB_API_URL="$GITHUB_API_URL" \
-            -e GITHUB_REPOSITORY="$GITHUB_REPOSITORY" \
-            -e GITHUB_RUN_ID="$GITHUB_RUN_ID" \
-            -e GITHUB_AUTH_TOKEN="$GITHUB_AUTH_TOKEN" \
-            -e GITHUB_SHA="$GITHUB_SHA" \
-            -e GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" \
             -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
             -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
             -e ALLURE_JOB_NAME="rspec" \
             publisher:latest \
-            upload s3 \
+            upload ${{ matrix.provider }} \
               --results-glob="/workspace/reports/allure-results" \
-              --bucket="allure-tests-reports" \
+              --bucket="${{ matrix.bucket }}" \
               --prefix="allure-report-publisher/$GITHUB_REF" \
-              --update-pr="description" \
+              --update-pr="${{ matrix.results }}" \
               --summary="behaviors" \
-              --summary-table-type="ascii" \
+              --summary-table-type="${{ matrix.table }}" \
               --copy-latest \
               --color

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,11 +64,11 @@ jobs:
         include:
           - provider: gcs
             bucket: allure-test-reports
-            table: ascii
+            table: markdown
             results: actions
           - provider: s3
             bucket: allure-tests-reports
-            table: markdown
+            table: ascii
             results: description
     steps:
       -


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/380/merge/3256360142/index.html) for [fc57785e](https://github.com/andrcuns/allure-report-publisher/pull/380/commits/fc57785e7e63bf0ed92426a95792f7411ff43011)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| helpers   | 41     | 0      | 0       | 0     | 41    | ✅     |
| providers | 16     | 0      | 0       | 0     | 16    | ✅     |
| uploaders | 17     | 0      | 0       | 0     | 17    | ✅     |
| commands  | 19     | 0      | 0       | 0     | 19    | ✅     |
| cli       | 1      | 0      | 0       | 0     | 1     | ✅     |
| generator | 3      | 0      | 0       | 0     | 3     | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 97     | 0      | 0       | 0     | 97    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->