### PR TITLE
Test on multiple ruby versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,15 +27,19 @@ jobs:
 
   rspec:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['2.7', '3.0', '3.1']
     steps:
       -
         name: Checkout
         uses: actions/checkout@v3
       -
-        name: Set up Ruby 3.1
+        name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1.2
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       -
         name: RSpec
@@ -43,6 +47,7 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: c782e3e534f6aac1bb5a0d595723167ed145d03567242c2ce848ef46ba36672a
           COVERAGE: "true"
+          ALLURE_ENVIRONMENT: ruby-${{ matrix.ruby }}
         with:
           coverageCommand: bundle exec rspec --force-color
           coverageLocations: coverage/coverage.json:simplecov
@@ -52,6 +57,7 @@ jobs:
         with:
           name: allure-reports
           path: reports/allure-results/
+          retention-days: 1
 
   publish-report:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/382/merge/3257496910/index.html) for [59df1627](https://github.com/andrcuns/allure-report-publisher/pull/382/commits/59df16271917516281055955012e8ee285b9e88b)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| helpers   | 123    | 0      | 0       | 0     | 123   | ✅     |
| uploaders | 51     | 0      | 0       | 0     | 51    | ✅     |
| generator | 9      | 0      | 0       | 0     | 9     | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| commands  | 57     | 0      | 0       | 0     | 57    | ✅     |
| providers | 48     | 0      | 0       | 0     | 48    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 291    | 0      | 0       | 0     | 291   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->