### PR TITLE
Remove explicit creation of allure reports destination path

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -15,9 +15,9 @@ changelog:
     - title: '📄 Documentation updates'
       labels: 
         - 'documentation'
-    - title: '🛠️ Chore'
+    - title: '🧰 Maintenance'
       labels: 
-        - 'chore'
+        - 'maintenance'
     - title: '👷 CI'
       labels: 
         - 'ci'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,11 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.0.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     allure-rspec (2.18.0)
@@ -49,6 +54,7 @@ GEM
     backport (1.2.0)
     benchmark (0.2.0)
     climate_control (1.2.0)
+    concurrent-ruby (1.1.10)
     debug (1.6.2)
       irb (>= 1.3.6)
       reline (>= 0.3.1)
@@ -109,6 +115,8 @@ GEM
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
     io-console (0.5.11)
     irb (1.4.2)
       reline (>= 0.3.0)
@@ -127,6 +135,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
+    minitest (5.16.3)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     nokogiri (1.13.8-aarch64-linux)
@@ -240,6 +249,8 @@ GEM
     tty-cursor (0.7.1)
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.3.0)
     uuid (2.3.9)
@@ -254,6 +265,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activesupport (~> 7.0)
   allure-report-publisher!
   allure-rspec (~> 2.18.0)
   climate_control (~> 1.2.0)

--- a/allure-report-publisher.gemspec
+++ b/allure-report-publisher.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "terminal-table", "~> 3.0"
   spec.add_dependency "tty-spinner", "~> 0.9.3"
 
+  spec.add_development_dependency "activesupport", "~> 7.0"
   spec.add_development_dependency "allure-rspec", "~> 2.18.0"
   spec.add_development_dependency "climate_control", "~> 1.2.0"
   spec.add_development_dependency "debug", ">= 1.0.0"

--- a/lib/allure_report_publisher/lib/helpers/gsutil.rb
+++ b/lib/allure_report_publisher/lib/helpers/gsutil.rb
@@ -25,6 +25,7 @@ module Publisher
 
         log_debug("Checking google credentials")
         check_credentials
+        log_debug("Credentials valid, gsutil initialized")
         self
       rescue StandardError => e
         case e

--- a/lib/allure_report_publisher/lib/report_generator.rb
+++ b/lib/allure_report_publisher/lib/report_generator.rb
@@ -19,7 +19,6 @@ module Publisher
     # @return [void]
     def generate
       create_common_path
-      create_report_path
 
       generate_report
     end
@@ -38,11 +37,8 @@ module Publisher
     #
     # @return [String]
     def report_path
-      @report_path ||= Dir.mktmpdir("allure-report").tap do |path|
-        log_debug("Created tmp folder for allure report: '#{path}'")
-      end
+      @report_path ||= File.join(Dir.tmpdir, "allure-report-#{Time.now.to_i}")
     end
-    alias create_report_path report_path
 
     private
 

--- a/lib/allure_report_publisher/lib/report_generator.rb
+++ b/lib/allure_report_publisher/lib/report_generator.rb
@@ -63,7 +63,7 @@ module Publisher
       log_debug("Generating allure report from following paths: #{result_paths}")
       cmd = "allure generate --clean --output #{report_path} #{common_info_path} #{result_paths}"
       out = execute_shell(cmd)
-      log_debug("Generated allure report, output: #{out}")
+      log_debug("Generated allure report. #{out}")
     rescue StandardError => e
       raise(AllureError, e.message)
     end

--- a/spec/allure_report_publisher/helpers/gsutil_spec.rb
+++ b/spec/allure_report_publisher/helpers/gsutil_spec.rb
@@ -25,7 +25,7 @@ RSpec.shared_examples "unsuccessful initialization" do
   end
 end
 
-RSpec.describe Publisher::Helpers::Gsutil do
+RSpec.describe Publisher::Helpers::Gsutil, epic: "helpers" do
   subject(:gsutil) { described_class.init }
 
   let(:status) { instance_double(Process::Status, success?: command_status) }


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/384/merge/3261392359/index.html) for [e441fa28](https://github.com/andrcuns/allure-report-publisher/pull/384/commits/e441fa28236d94a1416835eecaf650c819cbdd6d)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| helpers   | 144    | 0      | 0       | 0     | 144   | ✅     |
| commands  | 63     | 0      | 0       | 0     | 63    | ✅     |
| providers | 48     | 0      | 0       | 0     | 48    | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| generator | 9      | 0      | 0       | 0     | 9     | ✅     |
| uploaders | 57     | 0      | 0       | 0     | 57    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 324    | 0      | 0       | 0     | 324   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->