### PR TITLE
Use gsutil rsync to correctly copy reports

### DIFF
--- a/lib/allure_report_publisher/lib/helpers/gsutil.rb
+++ b/lib/allure_report_publisher/lib/helpers/gsutil.rb
@@ -63,7 +63,7 @@ module Publisher
           execute_shell([
             base_cmd(key_file),
             "-h 'Cache-Control:private, max-age=#{cache_control}'",
-            "cp -r #{source_dir} gs://#{bucket}/#{destination_dir}"
+            "rsync -r #{source_dir} gs://#{bucket}/#{destination_dir}"
           ].join(" "))
         end
         log_debug("Finished upload successfully")

--- a/spec/allure_report_publisher/helpers/gsutil_spec.rb
+++ b/spec/allure_report_publisher/helpers/gsutil_spec.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples "successfull gsutil upload" do
     expect(Open3).to have_received(:capture3).with([
       "gsutil -o 'Credentials:gs_service_key_file=#{credentials_file}' -m",
       "-h 'Cache-Control:private, max-age=#{cache_control}'",
-      "cp -r #{report_path} gs://#{bucket_name}/#{destination_dir}"
+      "rsync -r #{report_path} gs://#{bucket_name}/#{destination_dir}"
     ].join(" "))
   end
 


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/385/merge/3261464672/index.html) for [bab7a97e](https://github.com/andrcuns/allure-report-publisher/pull/385/commits/bab7a97e8c092559e96f0df86cc1615a82ebd573)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| helpers   | 144    | 0      | 0       | 0     | 144   | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| commands  | 63     | 0      | 0       | 0     | 63    | ✅     |
| providers | 48     | 0      | 0       | 0     | 48    | ✅     |
| uploaders | 57     | 0      | 0       | 0     | 57    | ✅     |
| generator | 9      | 0      | 0       | 0     | 9     | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 324    | 0      | 0       | 0     | 324   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->