### PR TITLE
Copy latest report within a bucket instead of host for gcs

### DIFF
--- a/lib/allure_report_publisher/lib/uploaders/gcs.rb
+++ b/lib/allure_report_publisher/lib/uploaders/gcs.rb
@@ -62,7 +62,7 @@ module Publisher
       # @return [void]
       def upload_history
         log_debug("Uploading report history")
-        upload_to_gcs(report_files.select { |file| file.fnmatch?("*/history/*") }, prefix)
+        file_upload(report_files.select { |file| file.fnmatch?("*/history/*") }, prefix)
       end
 
       # Upload allure report
@@ -70,9 +70,9 @@ module Publisher
       # @return [void]
       def upload_report
         log_debug("Uploading report files")
-        return batch_upload_to_gcs(report_path, full_prefix) if gsutil.valid?
+        return batch_upload(report_path, full_prefix) if gsutil.valid?
 
-        upload_to_gcs(report_files, full_prefix)
+        file_upload(report_files, full_prefix)
       end
 
       # Upload copy of latest run
@@ -80,9 +80,9 @@ module Publisher
       # @return [void]
       def upload_latest_copy
         log_debug("Uploading report copy as latest report")
-        return batch_upload_to_gcs(report_path, prefix, cache_control: 60) if gsutil.valid?
+        return batch_copy(full_prefix, prefix, cache_control: 60) if gsutil.valid?
 
-        upload_to_gcs(report_files, prefix, cache_control: 60)
+        file_upload(report_files, prefix, cache_control: 60)
       end
 
       # Upload files to gcs
@@ -91,7 +91,7 @@ module Publisher
       # @param [String] key_prefix
       # @param [Hash] params
       # @return [void]
-      def upload_to_gcs(files, key_prefix, cache_control: 3600)
+      def file_upload(files, key_prefix, cache_control: 3600)
         threads = 8
         args = files.map do |file|
           {
@@ -108,12 +108,27 @@ module Publisher
         log_debug("Finished upload successfully")
       end
 
-      # Batch upload whole directory
+      # Upload directory recursively
       #
       # @param [String] source_dir
       # @param [String] destination_dir
       # @return [void]
-      def batch_upload_to_gcs(source_dir, destination_dir, cache_control: 3600)
+      def batch_upload(source_dir, destination_dir, cache_control: 3600)
+        gsutil.batch_upload(
+          source_dir: source_dir,
+          destination_dir: destination_dir,
+          bucket: bucket_name,
+          cache_control: cache_control
+        )
+      end
+
+      # Copy directory within the bucket
+      #
+      # @param [String] source_dir
+      # @param [String] destination_dir
+      # @param [String] cache_control
+      # @return [void]
+      def batch_copy(source_dir, destination_dir, cache_control: 3600)
         gsutil.batch_copy(
           source_dir: source_dir,
           destination_dir: destination_dir,

--- a/spec/allure_report_publisher/helpers/gsutil_spec.rb
+++ b/spec/allure_report_publisher/helpers/gsutil_spec.rb
@@ -1,4 +1,21 @@
 RSpec.shared_examples "successfull gsutil upload" do
+  it "performs upload command" do
+    gsutil.batch_upload(
+      source_dir: report_path,
+      destination_dir: destination_dir,
+      bucket: bucket_name,
+      cache_control: cache_control
+    )
+
+    expect(Open3).to have_received(:capture3).with([
+      "gsutil -o 'Credentials:gs_service_key_file=#{credentials_file}' -m",
+      "-h 'Cache-Control:private, max-age=#{cache_control}'",
+      "rsync",
+      "-j json,csv,txt,js,css",
+      "-r #{report_path} gs://#{bucket_name}/#{destination_dir}"
+    ].join(" "))
+  end
+
   it "performs copy command" do
     gsutil.batch_copy(
       source_dir: report_path,
@@ -12,7 +29,7 @@ RSpec.shared_examples "successfull gsutil upload" do
       "-h 'Cache-Control:private, max-age=#{cache_control}'",
       "rsync",
       "-j json,csv,txt,js,css",
-      "-r #{report_path} gs://#{bucket_name}/#{destination_dir}"
+      "-r gs://#{bucket_name}/#{report_path} gs://#{bucket_name}/#{destination_dir}"
     ].join(" "))
   end
 


### PR DESCRIPTION
Do not perform unnecessary copy from source when creating a latest report copy.

<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ❌ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/393/merge/3293796048/index.html) for [266ebea3](https://github.com/andrcuns/allure-report-publisher/pull/393/commits/266ebea393e13e31314f688c133a228322204a61)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| providers | 48     | 0      | 0       | 0     | 48    | ✅     |
| uploaders | 51     | 6      | 0       | 0     | 57    | ❌     |
| helpers   | 138    | 6      | 0       | 0     | 144   | ❌     |
| commands  | 63     | 0      | 0       | 0     | 63    | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| generator | 9      | 0      | 0       | 0     | 9     | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 312    | 12     | 0       | 0     | 324   | ❌     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->