### PR TITLE
Do not scan result paths glob twice

### DIFF
--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -130,7 +130,7 @@ module Publisher
         results_glob = args[:results_glob]
         ignore = args[:ignore_missing_results]
         @result_paths = Dir.glob(results_glob)
-        log_debug("Found #{@result_paths.size} allure results paths")
+        log_debug("Glob '#{results_glob}' found #{@result_paths.size} paths")
         return unless @result_paths.empty?
 
         log("Glob '#{results_glob}' did not match any paths!", ignore ? :yellow : :red)

--- a/lib/allure_report_publisher/lib/report_generator.rb
+++ b/lib/allure_report_publisher/lib/report_generator.rb
@@ -10,8 +10,8 @@ module Publisher
   class ReportGenerator
     include Helpers
 
-    def initialize(results_glob)
-      @results_glob = results_glob
+    def initialize(result_paths)
+      @result_paths = result_paths.join(" ")
     end
 
     # Generate allure report
@@ -42,19 +42,8 @@ module Publisher
 
     private
 
-    attr_reader :results_glob
-
-    # Return all allure results paths from glob
-    #
-    # @return [String]
-    def result_paths
-      @result_paths ||= begin
-        paths = Dir.glob(results_glob)
-        raise(NoAllureResultsError, "Missing allure results") if paths.empty?
-
-        paths.join(" ")
-      end
-    end
+    # @return [String] result paths string
+    attr_reader :result_paths
 
     # Generate allure report
     #

--- a/lib/allure_report_publisher/lib/report_generator.rb
+++ b/lib/allure_report_publisher/lib/report_generator.rb
@@ -49,7 +49,7 @@ module Publisher
     #
     # @return [void]
     def generate_report
-      log_debug("Generating allure report from following paths: #{result_paths}")
+      log_debug("Generating allure report")
       cmd = "allure generate --clean --output #{report_path} #{common_info_path} #{result_paths}"
       out = execute_shell(cmd)
       log_debug("Generated allure report. #{out}")

--- a/lib/allure_report_publisher/lib/uploaders/_uploader.rb
+++ b/lib/allure_report_publisher/lib/uploaders/_uploader.rb
@@ -23,7 +23,7 @@ module Publisher
       # Uploader instance
       #
       # @param [Hash] args
-      # @option args [String] :results_glob
+      # @option args [Array] :result_paths
       # @option args [String] :bucket
       # @option args [String] :prefix
       # @option args [Boolean] :update_pr
@@ -32,7 +32,7 @@ module Publisher
       # @option args [Boolean] :collapse_summary
       # @option args [String] :copy_latest
       def initialize(**args)
-        @results_glob = args[:results_glob]
+        @result_paths = args[:result_paths]
         @bucket_name = args[:bucket]
         @prefix = args[:prefix]
         @update_pr = args[:update_pr]
@@ -97,7 +97,7 @@ module Publisher
 
       private
 
-      attr_reader :results_glob,
+      attr_reader :result_paths,
                   :bucket_name,
                   :prefix,
                   :update_pr,
@@ -164,7 +164,7 @@ module Publisher
       #
       # @return [Publisher::ReportGenerator]
       def report_generator
-        @report_generator ||= ReportGenerator.new(results_glob)
+        @report_generator ||= ReportGenerator.new(result_paths)
       end
 
       # Report path prefix

--- a/spec/allure_report_publisher/commands/common_uploader_command.rb
+++ b/spec/allure_report_publisher/commands/common_uploader_command.rb
@@ -2,7 +2,8 @@ RSpec.shared_examples "upload command" do
   include_context "with cli helper"
   include_context "with output capture"
 
-  let(:result_glob) { "**/*" }
+  let(:result_glob) { "spec/fixture/fake_results" }
+  let(:result_paths) { [result_glob] }
   let(:bucket) { "bucket" }
   let(:prefix) { "my-project/prs" }
   let(:uploader_stub) do
@@ -26,7 +27,7 @@ RSpec.shared_examples "upload command" do
 
   let(:args) do
     {
-      results_glob: result_glob,
+      result_paths: result_paths,
       bucket: bucket,
       prefix: prefix,
       copy_latest: false,
@@ -55,8 +56,8 @@ RSpec.shared_examples "upload command" do
 
       aggregate_failures do
         expect(uploader).to have_received(:new).with(
-          args.slice(
-            :results_glob,
+          **args.slice(
+            :result_paths,
             :bucket,
             :copy_latest,
             :update_pr,

--- a/spec/allure_report_publisher/lib/report_generator_spec.rb
+++ b/spec/allure_report_publisher/lib/report_generator_spec.rb
@@ -3,13 +3,13 @@ require "active_support/testing/time_helpers"
 RSpec.describe Publisher::ReportGenerator, epic: "generator" do
   include ActiveSupport::Testing::TimeHelpers
 
-  subject(:report_generator) { described_class.new(results_glob) }
+  subject(:report_generator) { described_class.new(result_paths) }
 
   include_context "with mock helper"
 
   let(:capture_status) { instance_double(Process::Status, success?: status) }
 
-  let(:results_glob) { "spec/fixture/fake_results" }
+  let(:result_paths) { ["spec/fixture/fake_results"] }
   let(:common_info_dir) { "/common_info_results" }
   let(:report_dir) { File.join(tmpdir, "allure-report-#{Time.now.to_i}") }
   let(:status) { true }
@@ -27,17 +27,9 @@ RSpec.describe Publisher::ReportGenerator, epic: "generator" do
         report_generator.generate
 
         expect(Open3).to have_received(:capture3).with(
-          "allure generate --clean --output #{report_dir} #{common_info_dir} #{results_glob}"
+          "allure generate --clean --output #{report_dir} #{common_info_dir} #{result_paths.join(' ')}"
         )
       end
-    end
-  end
-
-  context "with empty allure results" do
-    let(:results_glob) { "spec/*.tar.gz" }
-
-    it "exits with missing allure results message" do
-      expect { report_generator.generate }.to raise_error("Missing allure results")
     end
   end
 
@@ -45,7 +37,7 @@ RSpec.describe Publisher::ReportGenerator, epic: "generator" do
     let(:status) { false }
     let(:error_output) do
       <<~ERR.strip
-        Command 'allure generate --clean --output #{report_dir} #{common_info_dir} #{results_glob}' failed!
+        Command 'allure generate --clean --output #{report_dir} #{common_info_dir} #{result_paths.join(' ')}' failed!
         Out: Allure output
       ERR
     end

--- a/spec/allure_report_publisher/lib/uploaders/common_uploader.rb
+++ b/spec/allure_report_publisher/lib/uploaders/common_uploader.rb
@@ -10,7 +10,7 @@ RSpec.shared_context "with uploader" do
     )
   end
 
-  let(:results_glob) { "spec/fixture/fake_results/*" }
+  let(:result_paths) { ["spec/fixture/fake_results"] }
   let(:bucket_name) { "bucket" }
   let(:prefix) { "project" }
   let(:ci_provider) { nil }
@@ -29,7 +29,7 @@ RSpec.shared_context "with uploader" do
 
   let(:args) do
     {
-      results_glob: results_glob,
+      result_paths: result_paths,
       bucket: bucket_name,
       prefix: prefix,
       update_pr: false,

--- a/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
       described_class.new(**args).execute
 
       aggregate_failures do
-        expect(Publisher::ReportGenerator).to have_received(:new).with(results_glob)
+        expect(Publisher::ReportGenerator).to have_received(:new).with(result_paths)
         expect(report_generator).to have_received(:generate)
       end
     end

--- a/spec/allure_report_publisher/lib/uploaders/s3_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/s3_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Publisher::Uploaders::S3, epic: "uploaders" do
       described_class.new(**args).execute
 
       aggregate_failures do
-        expect(Publisher::ReportGenerator).to have_received(:new).with(results_glob)
+        expect(Publisher::ReportGenerator).to have_received(:new).with(result_paths)
         expect(report_generator).to have_received(:generate)
       end
     end


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/396/merge/3302926502/index.html) for [bb0c3ae5](https://github.com/andrcuns/allure-report-publisher/pull/396/commits/bb0c3ae540e431943da1ecefb843b5ad7c5a3eef)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| providers | 48     | 0      | 0       | 0     | 48    | ✅     |
| uploaders | 57     | 0      | 0       | 0     | 57    | ✅     |
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| commands  | 63     | 0      | 0       | 0     | 63    | ✅     |
| helpers   | 150    | 0      | 0       | 0     | 150   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 327    | 0      | 0       | 0     | 327   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->