### PR TITLE
Copy latest report within bucket instead of uploading from host

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,10 @@ RSpec/MultipleMemoizedHelpers:
 
 RSpec/ExampleLength:
   Max: 20
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
 
 RSpec/FilePath:
   Enabled: false

--- a/lib/allure_report_publisher/lib/uploaders/_uploader.rb
+++ b/lib/allure_report_publisher/lib/uploaders/_uploader.rb
@@ -5,6 +5,8 @@ module Publisher
   module Uploaders
     class HistoryNotFoundError < StandardError; end
 
+    PARALLEL_THREADS = 8
+
     # Uploader implementation
     #
     class Uploader

--- a/lib/allure_report_publisher/lib/uploaders/_uploader.rb
+++ b/lib/allure_report_publisher/lib/uploaders/_uploader.rb
@@ -67,7 +67,9 @@ module Publisher
       #
       # @return [void]
       def upload
-        run_uploads
+        upload_history unless !run_id || copy_latest
+        upload_report
+        upload_latest_copy if copy_latest
       end
 
       # Add allure report url to pull request description
@@ -234,15 +236,6 @@ module Publisher
         log_debug("Saving ci executor info")
         File.write(json_path, json)
         log_debug("Saved '#{EXECUTOR_JSON}' as '#{json_path}'\n#{JSON.pretty_generate(ci_provider.executor_info)}")
-      end
-
-      # Run upload commands
-      #
-      # @return [void]
-      def run_uploads
-        upload_history unless !run_id || copy_latest
-        upload_report
-        upload_latest_copy if copy_latest
       end
 
       # Fetch allure report history

--- a/lib/allure_report_publisher/lib/uploaders/gcs.rb
+++ b/lib/allure_report_publisher/lib/uploaders/gcs.rb
@@ -82,7 +82,9 @@ module Publisher
         end
 
         Parallel.each(args, in_threads: PARALLEL_THREADS) do |obj|
-          obj[:source_file].copy(bucket_name, obj[:destination])
+          obj[:source_file].copy(obj[:destination], force_copy_metadata: true) do |f|
+            f.metadata["cache_control"] = "public, max-age=60"
+          end
         end
         log_debug("Finished latest report copy successfully")
       end

--- a/lib/allure_report_publisher/lib/uploaders/gcs.rb
+++ b/lib/allure_report_publisher/lib/uploaders/gcs.rb
@@ -83,7 +83,7 @@ module Publisher
 
         Parallel.each(args, in_threads: PARALLEL_THREADS) do |obj|
           obj[:source_file].copy(obj[:destination], force_copy_metadata: true) do |f|
-            f.metadata["Cache-Control"] = "public, max-age=60"
+            f.cache_control = "public, max-age=60"
           end
         end
         log_debug("Finished latest report copy successfully")

--- a/lib/allure_report_publisher/lib/uploaders/gcs.rb
+++ b/lib/allure_report_publisher/lib/uploaders/gcs.rb
@@ -95,18 +95,17 @@ module Publisher
       # @param [String] key_prefix
       # @param [Hash] params
       # @return [Array<Hash>]
-      def upload_to_gcs(files, key_prefix, cache_control: 3600)
+      def upload_to_gcs(files, key_prefix)
         args = files.map do |file|
           {
             file: file.to_s,
             path: key(key_prefix, file.relative_path_from(report_path)),
-            cache_control: "public, max-age=#{cache_control}"
           }
         end
 
         log_debug("Uploading '#{args.size}' files in '#{PARALLEL_THREADS}' threads")
         Parallel.each(args, in_threads: PARALLEL_THREADS) do |obj|
-          bucket.create_file(*obj.slice(:file, :path).values, **obj.slice(:cache_control))
+          bucket.create_file(*obj.slice(:file, :path).values, cache_control: "public, max-age=3600")
         end
         log_debug("Finished upload successfully")
       end

--- a/lib/allure_report_publisher/lib/uploaders/gcs.rb
+++ b/lib/allure_report_publisher/lib/uploaders/gcs.rb
@@ -99,7 +99,7 @@ module Publisher
         args = files.map do |file|
           {
             file: file.to_s,
-            path: key(key_prefix, file.relative_path_from(report_path)),
+            path: key(key_prefix, file.relative_path_from(report_path))
           }
         end
 

--- a/lib/allure_report_publisher/lib/uploaders/gcs.rb
+++ b/lib/allure_report_publisher/lib/uploaders/gcs.rb
@@ -5,8 +5,6 @@ module Publisher
     # Google cloud storage uploader implementation
     #
     class GCS < Uploader
-      PARALLEL_THREADS = 8
-
       private
 
       # GCS client

--- a/lib/allure_report_publisher/lib/uploaders/gcs.rb
+++ b/lib/allure_report_publisher/lib/uploaders/gcs.rb
@@ -83,7 +83,7 @@ module Publisher
 
         Parallel.each(args, in_threads: PARALLEL_THREADS) do |obj|
           obj[:source_file].copy(obj[:destination], force_copy_metadata: true) do |f|
-            f.metadata["cache_control"] = "public, max-age=60"
+            f.metadata["Cache-Control"] = "public, max-age=60"
           end
         end
         log_debug("Finished latest report copy successfully")

--- a/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
     it "uploads latest allure report copy" do
       described_class.new(**{ **args, copy_latest: true }).execute
 
-      expect(history[:file]).to have_received(:copy).with(bucket_name, history[:gcs_path_latest])
-      expect(report[:file]).to have_received(:copy).with(bucket_name, report[:gcs_path_latest])
+      expect(history[:file]).to have_received(:copy).with(history[:gcs_path_latest], force_copy_metadata: true)
+      expect(report[:file]).to have_received(:copy).with(report[:gcs_path_latest], force_copy_metadata: true)
     end
 
     it "adds executor info" do

--- a/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
   let(:client) { instance_double(Google::Cloud::Storage::Project, bucket: bucket) }
   let(:bucket) { instance_double(Google::Cloud::Storage::Bucket, create_file: nil, file: file) }
   let(:file) { instance_double(Google::Cloud::Storage::File, download: nil, copy: nil) }
+  let(:cache_control) { { cache_control: "public, max-age=3600" } }
 
   let(:history) do
     {
@@ -24,10 +25,6 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
       gcs_path_run: "#{prefix}/#{run_id}/index.html",
       gcs_path_latest: "#{prefix}/index.html"
     }
-  end
-
-  def cache_control(max_age = 3600)
-    { cache_control: "public, max-age=#{max_age}" }
   end
 
   before do

--- a/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
@@ -1,16 +1,30 @@
 require_relative "common_uploader"
 
+# rubocop:disable Layout/LineLength
 RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
   include_context "with uploader"
 
   let(:client) { instance_double(Google::Cloud::Storage::Project, bucket: bucket) }
-  let(:bucket) { instance_double(Google::Cloud::Storage::Bucket, file: file, create_file: nil) }
-  let(:file) { instance_double(Google::Cloud::Storage::File, download: nil) }
+  let(:bucket) { instance_double(Google::Cloud::Storage::Bucket, create_file: nil, file: file) }
+  let(:file) { instance_double(Google::Cloud::Storage::File, download: nil, copy: nil) }
 
-  let(:history_run) { ["spec/fixture/fake_report/history/history.json", "#{prefix}/#{run_id}/history/history.json"] }
-  let(:history) { ["spec/fixture/fake_report/history/history.json", "#{prefix}/history/history.json"] }
-  let(:report_run) { ["spec/fixture/fake_report/index.html", "#{prefix}/#{run_id}/index.html"] }
-  let(:report) { ["spec/fixture/fake_report/index.html", "#{prefix}/index.html"] }
+  let(:history) do
+    {
+      file: instance_double(Google::Cloud::Storage::File, download: nil, copy: nil),
+      path: "spec/fixture/fake_report/history/history.json",
+      gcs_path_run: "#{prefix}/#{run_id}/history/history.json",
+      gcs_path_latest: "#{prefix}/history/history.json"
+    }
+  end
+
+  let(:report) do
+    {
+      file: instance_double(Google::Cloud::Storage::File, download: nil, copy: nil),
+      path: "spec/fixture/fake_report/index.html",
+      gcs_path_run: "#{prefix}/#{run_id}/index.html",
+      gcs_path_latest: "#{prefix}/index.html"
+    }
+  end
 
   def cache_control(max_age = 3600)
     { cache_control: "public, max-age=#{max_age}" }
@@ -34,8 +48,8 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
       described_class.new(**args).execute
 
       aggregate_failures do
-        expect(bucket).to have_received(:create_file).with(*report, cache_control)
-        expect(bucket).to have_received(:create_file).with(*history, cache_control)
+        expect(bucket).to have_received(:create_file).with(*report.slice(:path, :gcs_path_latest).values, cache_control)
+        expect(bucket).to have_received(:create_file).with(*history.slice(:path, :gcs_path_latest).values, cache_control)
       end
     end
 
@@ -61,6 +75,9 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
       allow(File).to receive(:write)
       allow(Publisher::Providers::Github).to receive(:run_id).and_return(1)
       allow(Publisher::Providers::Github).to receive(:new) { ci_provider_instance }
+
+      allow(bucket).to receive(:file).with(history[:gcs_path_run]) { history[:file] }
+      allow(bucket).to receive(:file).with(report[:gcs_path_run]) { report[:file] }
     end
 
     it "uploads allure report" do
@@ -72,17 +89,17 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
           expect(file).to have_received(:download).with("#{common_info_path}/history/#{f}")
         end
 
-        expect(bucket).to have_received(:create_file).with(*history, cache_control)
-        expect(bucket).to have_received(:create_file).with(*history_run, cache_control)
-        expect(bucket).to have_received(:create_file).with(*report_run, cache_control)
+        expect(bucket).to have_received(:create_file).with(*history.slice(:path, :gcs_path_latest).values, cache_control)
+        expect(bucket).to have_received(:create_file).with(*history.slice(:path, :gcs_path_run).values, cache_control)
+        expect(bucket).to have_received(:create_file).with(*report.slice(:path, :gcs_path_run).values, cache_control)
       end
     end
 
     it "uploads latest allure report copy" do
       described_class.new(**{ **args, copy_latest: true }).execute
 
-      expect(bucket).to have_received(:create_file).with(*report, cache_control(60))
-      expect(bucket).to have_received(:create_file).with(*report_run, cache_control)
+      expect(history[:file]).to have_received(:copy).with(bucket_name, history[:gcs_path_latest])
+      expect(report[:file]).to have_received(:copy).with(bucket_name, report[:gcs_path_latest])
     end
 
     it "adds executor info" do
@@ -103,3 +120,4 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
     end
   end
 end
+# rubocop:enable Layout/LineLength


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/410/merge/3411589335/index.html) for [ca2c1a49](https://github.com/andrcuns/allure-report-publisher/pull/410/commits/ca2c1a498ed046a44467fff2785f880bdce72163)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| commands  | 63     | 0      | 0       | 0     | 63    | ✅     |
| uploaders | 51     | 0      | 0       | 0     | 51    | ✅     |
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
| helpers   | 123    | 0      | 0       | 0     | 123   | ✅     |
| providers | 48     | 0      | 0       | 0     | 48    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 294    | 0      | 0       | 0     | 294   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->