### PR TITLE
deps: bump allure-cli from 2.19.0 to 2.20.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN gem build -o ${GEMFILE}
 FROM ruby as production
 
 # Install allure
-ARG ALLURE_VERSION=2.19.0
+ARG ALLURE_VERSION=2.20.1
 ENV PATH=$PATH:/usr/local/allure-${ALLURE_VERSION}/bin
 RUN apk --no-cache add openjdk17 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN set -eux; \


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/412/merge/3426613273/index.html) for [68df7cc3](https://github.com/andrcuns/allure-report-publisher/pull/412/commits/68df7cc3686cb8abe64a365091e9dfd4afb11f4b)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
| uploaders | 51     | 0      | 0       | 0     | 51    | ✅     |
| helpers   | 123    | 0      | 0       | 0     | 123   | ✅     |
| providers | 48     | 0      | 0       | 0     | 48    | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| commands  | 63     | 0      | 0       | 0     | 63    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 294    | 0      | 0       | 0     | 294   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->