### PR TITLE
Add option to set custom report base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Options:
   --update-pr=VALUE                 # Add report url to PR via comment or description update. Required: false: (comment/description/actions)
   --summary=VALUE                   # Additionally add summary table to PR comment or description. Required: false: (behaviors/suites/packages/total)
   --summary-table-type=VALUE        # Summary table type. Required: false: (ascii/markdown), default: :ascii
-  --[no-]collapse-summary           # Create summary as a collapsable section, default: false
+  --base-url=VALUE                  # Use custom base url instead of default cloud provider one. Required: false
+  --[no-]collapse-summary           # Create summary as a collapsible section, default: false
   --[no-]copy-latest                # Keep copy of latest report at base prefix path, default: false
   --[no-]color                      # Force color output
   --[no-]ignore-missing-results     # Ignore missing allure results, default: false

--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -48,7 +48,7 @@ module Publisher
       option :collapse_summary,
              type: :boolean,
              default: false,
-             desc: "Create summary as a collapsable section"
+             desc: "Create summary as a collapsible section"
       option :copy_latest,
              type: :boolean,
              default: false,

--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -1,3 +1,5 @@
+require "uri"
+
 module Publisher
   module Commands
     # Upload allure report
@@ -40,6 +42,9 @@ module Publisher
                Publisher::Helpers::Summary::ASCII,
                Publisher::Helpers::Summary::MARKDOWN
              ]
+      option :base_url,
+             type: :string,
+             desc: "Use custom base url instead of default cloud provider one. Required: false"
       option :collapse_summary,
              type: :boolean,
              default: false,
@@ -95,6 +100,7 @@ module Publisher
           **args.slice(
             :bucket,
             :prefix,
+            :base_url,
             :copy_latest,
             :update_pr,
             :collapse_summary,
@@ -120,6 +126,9 @@ module Publisher
       def validate_args
         error("Missing argument --results-glob!") unless args[:results_glob]
         error("Missing argument --bucket!") unless args[:bucket]
+        URI.parse(args[:base_url]) if args[:base_url]
+      rescue URI::InvalidURIError
+        error("Invalid --base-url value!")
       end
 
       # Scan for allure results paths

--- a/lib/allure_report_publisher/lib/uploaders/_uploader.rb
+++ b/lib/allure_report_publisher/lib/uploaders/_uploader.rb
@@ -28,6 +28,7 @@ module Publisher
       # @option args [Array] :result_paths
       # @option args [String] :bucket
       # @option args [String] :prefix
+      # @option args [String] :base_url
       # @option args [Boolean] :update_pr
       # @option args [String] :summary_type
       # @option args [Symbol] :summary_table_type
@@ -37,6 +38,7 @@ module Publisher
         @result_paths = args[:result_paths]
         @bucket_name = args[:bucket]
         @prefix = args[:prefix]
+        @base_url = args[:base_url]
         @update_pr = args[:update_pr]
         @summary_type = args[:summary_type]
         @summary_table_type = args[:summary_table_type]
@@ -104,6 +106,7 @@ module Publisher
       attr_reader :result_paths,
                   :bucket_name,
                   :prefix,
+                  :base_url,
                   :update_pr,
                   :copy_latest,
                   :summary_type,

--- a/lib/allure_report_publisher/lib/uploaders/gcs.rb
+++ b/lib/allure_report_publisher/lib/uploaders/gcs.rb
@@ -121,7 +121,7 @@ module Publisher
       # @param [String] path_prefix
       # @return [String]
       def url(path_prefix)
-        ["https://storage.googleapis.com", bucket_name, path_prefix, "index.html"].compact.join("/")
+        [base_url || "https://storage.googleapis.com", bucket_name, path_prefix, "index.html"].compact.join("/")
       end
     end
   end

--- a/lib/allure_report_publisher/lib/uploaders/s3.rb
+++ b/lib/allure_report_publisher/lib/uploaders/s3.rb
@@ -132,7 +132,7 @@ module Publisher
       # @param [String] path_prefix
       # @return [String]
       def url(path_prefix)
-        ["http://#{bucket_name}.s3.amazonaws.com", path_prefix, "index.html"].compact.join("/")
+        [base_url || "http://#{bucket_name}.s3.amazonaws.com", path_prefix, "index.html"].compact.join("/")
       end
     end
   end

--- a/spec/allure_report_publisher/commands/common_uploader_command.rb
+++ b/spec/allure_report_publisher/commands/common_uploader_command.rb
@@ -126,6 +126,18 @@ RSpec.shared_examples "upload command" do
         expect(uploader_stub).to have_received(:add_result_summary)
       end
     end
+
+    it "executes uploader with custom --base-url" do
+      base_url = "https://custom"
+
+      run_cli(*command, *cli_args, "--base-url=#{base_url}")
+
+      aggregate_failures do
+        expect(uploader).to have_received(:new).with({ **args, base_url: base_url })
+        expect(uploader_stub).to have_received(:generate_report)
+        expect(uploader_stub).to have_received(:upload)
+      end
+    end
   end
 
   context "with missing args", :aggregate_failures do
@@ -137,6 +149,14 @@ RSpec.shared_examples "upload command" do
 
     it "exits when bucket is missing" do
       expect { run_cli(*command, cli_args[0]) }.to raise_error(SystemExit)
+      expect(uploader_stub).not_to have_received(:generate_report)
+      expect(uploader_stub).not_to have_received(:upload)
+    end
+  end
+
+  context "with invalid base-url" do
+    it "fails with invalid url error" do
+      expect { run_cli(*command, *cli_args, "--base-url=https://bla bla") }.to raise_error(SystemExit)
       expect(uploader_stub).not_to have_received(:generate_report)
       expect(uploader_stub).not_to have_received(:upload)
     end

--- a/spec/allure_report_publisher/lib/uploaders/common_uploader.rb
+++ b/spec/allure_report_publisher/lib/uploaders/common_uploader.rb
@@ -13,6 +13,7 @@ RSpec.shared_context "with uploader" do
   let(:result_paths) { ["spec/fixture/fake_results"] }
   let(:bucket_name) { "bucket" }
   let(:prefix) { "project" }
+  let(:base_url) { nil }
   let(:ci_provider) { nil }
   let(:run_id) { 1 }
   let(:executor_info) { { name: "Github" } }
@@ -32,6 +33,7 @@ RSpec.shared_context "with uploader" do
       result_paths: result_paths,
       bucket: bucket_name,
       prefix: prefix,
+      base_url: base_url,
       update_pr: false,
       copy_latest: false
     }

--- a/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
@@ -109,11 +109,24 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
       expect(ci_provider_instance).to have_received(:add_result_summary)
     end
 
-    it "returns correct uploader report urls" do
-      expect(described_class.new(**args, copy_latest: true).report_urls).to eq({
-        "Report url" => "https://storage.googleapis.com/bucket/project/1/index.html",
-        "Latest report url" => "https://storage.googleapis.com/bucket/project/index.html"
-      })
+    context "with default base url" do
+      it "returns correct report urls" do
+        expect(described_class.new(**args, copy_latest: true).report_urls).to eq({
+          "Report url" => "https://storage.googleapis.com/bucket/project/1/index.html",
+          "Latest report url" => "https://storage.googleapis.com/bucket/project/index.html"
+        })
+      end
+    end
+
+    context "with custom base url" do
+      let(:base_url) { "http://custom-url" }
+
+      it "returns correct report urls" do
+        expect(described_class.new(**args, copy_latest: true).report_urls).to eq({
+          "Report url" => "#{base_url}/bucket/project/1/index.html",
+          "Latest report url" => "#{base_url}/bucket/project/index.html"
+        })
+      end
     end
   end
 end

--- a/spec/allure_report_publisher/lib/uploaders/s3_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/s3_spec.rb
@@ -151,11 +151,24 @@ RSpec.describe Publisher::Uploaders::S3, epic: "uploaders" do
       expect(ci_provider_instance).to have_received(:add_result_summary)
     end
 
-    it "returns correct uploader report urls" do
-      expect(described_class.new(**args, copy_latest: true).report_urls).to eq({
-        "Report url" => "http://bucket.s3.amazonaws.com/project/1/index.html",
-        "Latest report url" => "http://bucket.s3.amazonaws.com/project/index.html"
-      })
+    context "with default base url" do
+      it "returns correct report urls" do
+        expect(described_class.new(**args, copy_latest: true).report_urls).to eq({
+          "Report url" => "http://bucket.s3.amazonaws.com/project/1/index.html",
+          "Latest report url" => "http://bucket.s3.amazonaws.com/project/index.html"
+        })
+      end
+    end
+
+    context "with custom base url" do
+      let(:base_url) { "http://custom-url" }
+
+      it "returns correct report urls" do
+        expect(described_class.new(**args, copy_latest: true).report_urls).to eq({
+          "Report url" => "#{base_url}/project/1/index.html",
+          "Latest report url" => "#{base_url}/project/index.html"
+        })
+      end
     end
   end
 end


### PR DESCRIPTION
Adds new option `--base-url` which replaces default cloud provider base url with custom one

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/429/merge/3742928354/index.html) for [69b4015c](https://github.com/andrcuns/allure-report-publisher/pull/429/commits/69b4015ccbf79a08aa70830be0c6ae63150944fa)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| uploaders | 57     | 0      | 0       | 0     | 57    | ✅     |
| helpers   | 123    | 0      | 0       | 0     | 123   | ✅     |
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| commands  | 75     | 0      | 0       | 0     | 75    | ✅     |
| providers | 48     | 0      | 0       | 0     | 48    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 312    | 0      | 0       | 0     | 312   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->