### PR TITLE
Clean up data folder in latest report copy

### DIFF
--- a/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
   let(:report) do
     {
       file: instance_double(Google::Cloud::Storage::File, download: nil, copy: nil),
+      existing_file: instance_double(Google::Cloud::Storage::File, delete: nil),
       path: "spec/fixture/fake_report/index.html",
       gcs_path_run: "#{prefix}/#{run_id}/index.html",
       gcs_path_latest: "#{prefix}/index.html"
@@ -75,6 +76,7 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
 
       allow(bucket).to receive(:file).with(history[:gcs_path_run]) { history[:file] }
       allow(bucket).to receive(:file).with(report[:gcs_path_run]) { report[:file] }
+      allow(bucket).to receive(:files).with(prefix: "#{prefix}/data") { [report[:existing_file]] }
     end
 
     it "uploads allure report" do
@@ -97,6 +99,7 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
 
       expect(history[:file]).to have_received(:copy).with(history[:gcs_path_latest], force_copy_metadata: true)
       expect(report[:file]).to have_received(:copy).with(report[:gcs_path_latest], force_copy_metadata: true)
+      expect(report[:existing_file]).to have_received(:delete)
     end
 
     it "adds executor info" do


### PR DESCRIPTION
Fixes bloat of unique report files from previous runs in `data` folder for latest report copy

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/432/merge/3777875443/index.html) for [bc47fe17](https://github.com/andrcuns/allure-report-publisher/pull/432/commits/bc47fe1751b5d617be4947e118d64797086ef6a9)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| providers | 48     | 0      | 0       | 0     | 48    | ✅     |
| commands  | 75     | 0      | 0       | 0     | 75    | ✅     |
| uploaders | 57     | 0      | 0       | 0     | 57    | ✅     |
| helpers   | 123    | 0      | 0       | 0     | 123   | ✅     |
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 312    | 0      | 0       | 0     | 312   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->