### PR TITLE
Fix failure for latest copy upload to s3

### DIFF
--- a/lib/allure_report_publisher/lib/uploaders/s3.rb
+++ b/lib/allure_report_publisher/lib/uploaders/s3.rb
@@ -86,12 +86,10 @@ module Publisher
         # it's not possible to overwrite whole directory so we clean out unique data files from last run
         log_debug("Cleaning data files")
         client.list_objects_v2(bucket: bucket_name, prefix: key(prefix, "data")).each do |resp|
-          client.delete_objects({
-            bucket: bucket_name,
-            delete: {
-              objects: resp.contents.map { |obj| { key: obj.key } }
-            }
-          })
+          data_files = resp.contents.map { |obj| { key: obj.key } }
+          next if data_files.empty?
+
+          client.delete_objects({ bucket: bucket_name, delete: { objects: data_files } })
         end
 
         log_debug("Copying report files")


### PR DESCRIPTION
Fixes issue with uploading latest copy of report to s3

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/435/merge/3789517422/index.html) for [47fe36bf](https://github.com/andrcuns/allure-report-publisher/pull/435/commits/47fe36bfbd60a1fc1eadd894adaf18bd456c3c2d)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| providers | 48     | 0      | 0       | 0     | 48    | ✅     |
| commands  | 75     | 0      | 0       | 0     | 75    | ✅     |
| uploaders | 57     | 0      | 0       | 0     | 57    | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| helpers   | 123    | 0      | 0       | 0     | 123   | ✅     |
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 312    | 0      | 0       | 0     | 312   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->