### PR TITLE
Add Resolvable comment in GitLab

### DIFF
--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -60,6 +60,10 @@ module Publisher
              type: :boolean,
              default: false,
              desc: "Ignore missing allure results"
+      option :unresolved_discussion_on_failure,
+             type: :boolean,
+             default: false,
+             desc: "Add an unresolved discussion comment on test failure"
       option :debug,
              type: :boolean,
              default: false,
@@ -104,7 +108,8 @@ module Publisher
             :copy_latest,
             :update_pr,
             :collapse_summary,
-            :summary_table_type
+            :summary_table_type,
+            :unresolved_discussion_on_failure
           )
         )
       end

--- a/lib/allure_report_publisher/lib/helpers/helpers.rb
+++ b/lib/allure_report_publisher/lib/helpers/helpers.rb
@@ -54,6 +54,16 @@ module Publisher
       end
     end
 
+    # Return non empty environment variable value
+    #
+    # @param [String] name
+    # @return [String, nil]
+    def env(name)
+      return unless ENV[name] && !ENV[name].empty?
+
+      ENV[name]
+    end
+
     # Colorize string
     #
     # @param [String] message

--- a/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
+++ b/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
@@ -58,7 +58,7 @@ module Publisher
         url_section(job_entries: job_entries, separator: false)
       end
 
-      # Test run status emoji
+      # Check if summary has failed tests
       #
       # @return [Boolean]
       def summary_has_failures?

--- a/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
+++ b/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
@@ -62,7 +62,7 @@ module Publisher
       #
       # @return [Boolean]
       def summary_has_failures?
-        summary.status == "✅" ? false : true
+        summary.status != "✅"
       end
 
       attr_reader :report_url,

--- a/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
+++ b/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
@@ -58,13 +58,6 @@ module Publisher
         url_section(job_entries: job_entries, separator: false)
       end
 
-      # Check if summary has failed tests
-      #
-      # @return [Boolean]
-      def summary_has_failures?
-        summary.status == "❌"
-      end
-
       attr_reader :report_url,
                   :report_path,
                   :build_name,

--- a/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
+++ b/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
@@ -58,6 +58,13 @@ module Publisher
         url_section(job_entries: job_entries, separator: false)
       end
 
+      # Test run status emoji
+      #
+      # @return [Boolean]
+      def summary_has_failures?
+        summary.status == "✅" ? false : true
+      end
+
       attr_reader :report_url,
                   :report_path,
                   :build_name,

--- a/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
+++ b/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
@@ -62,7 +62,7 @@ module Publisher
       #
       # @return [Boolean]
       def summary_has_failures?
-        summary.status != "✅"
+        summary.status == "❌"
       end
 
       attr_reader :report_url,

--- a/lib/allure_report_publisher/lib/providers/_provider.rb
+++ b/lib/allure_report_publisher/lib/providers/_provider.rb
@@ -23,6 +23,7 @@ module Publisher
       # @option args [Boolean] :update_pr
       # @option args [String] :summary_type
       # @option args [Boolean] :collapse_summay
+      # @option args [Boolean] :unresolved_discussion_on_failure
       # @option args [Symbol] :summary_table_type
       def initialize(**args)
         @report_url = args[:report_url]
@@ -31,6 +32,7 @@ module Publisher
         @summary_type = args[:summary_type]
         @summary_table_type = args[:summary_table_type]
         @collapse_summary = args[:collapse_summary]
+        @unresolved_discussion_on_failure = args[:unresolved_discussion_on_failure]
       end
 
       # :nocov:
@@ -76,7 +78,8 @@ module Publisher
                   :update_pr,
                   :summary_type,
                   :collapse_summary,
-                  :summary_table_type
+                  :summary_table_type,
+                  :unresolved_discussion_on_failure
 
       # Current pull request description
       #

--- a/lib/allure_report_publisher/lib/providers/gitlab.rb
+++ b/lib/allure_report_publisher/lib/providers/gitlab.rb
@@ -58,8 +58,7 @@ module Publisher
         )
       end
 
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       # Add comment with report url
       #
       # @return [void]
@@ -67,8 +66,12 @@ module Publisher
         if main_comment
           log_debug("Updating summary in comment with id #{discussion.id} in mr !#{mr_iid}")
 
-          client.edit_merge_request_note(project, mr_iid, main_comment.id,
-                                         url_section_builder.comment_body(main_comment.body))
+          client.edit_merge_request_note(
+            project,
+            mr_iid,
+            main_comment.id,
+            url_section_builder.comment_body(main_comment.body)
+          )
         else
           log_debug("Creating comment with summary for mr ! #{mr_iid}")
           client.create_merge_request_comment(project, mr_iid, url_section_builder.comment_body)
@@ -77,14 +80,12 @@ module Publisher
         @discussion = nil
 
         if unresolved_discussion_on_failure && main_comment&.body&.include?("❌") && !alert_comment
-          client.create_merge_request_discussion_note(project, mr_iid, discussion.id,
-                                                      body: alert_comment_text)
+          client.create_merge_request_discussion_note(project, mr_iid, discussion.id, body: alert_comment_text)
         elsif alert_comment
           client.delete_merge_request_discussion_note(project, mr_iid, discussion.id, alert_comment.id)
         end
       end
-      # rubocop:enable Metrics/CyclomaticComplexity
-      # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       # Existing discussion that has comment with allure urls
       #

--- a/lib/allure_report_publisher/lib/uploaders/_uploader.rb
+++ b/lib/allure_report_publisher/lib/uploaders/_uploader.rb
@@ -33,6 +33,7 @@ module Publisher
       # @option args [String] :summary_type
       # @option args [Symbol] :summary_table_type
       # @option args [Boolean] :collapse_summary
+      # @option args [Boolean] :unresolved_discussion_on_failure
       # @option args [String] :copy_latest
       def initialize(**args)
         @result_paths = args[:result_paths]
@@ -44,6 +45,7 @@ module Publisher
         @summary_table_type = args[:summary_table_type]
         @copy_latest = (Providers.provider && args[:copy_latest]) # copy latest for ci only
         @collapse_summary = args[:collapse_summary]
+        @unresolved_discussion_on_failure = args[:unresolved_discussion_on_failure]
       end
 
       # Execute allure report generation and upload
@@ -111,7 +113,8 @@ module Publisher
                   :copy_latest,
                   :summary_type,
                   :collapse_summary,
-                  :summary_table_type
+                  :summary_table_type,
+                  :unresolved_discussion_on_failure
 
       def_delegators :report_generator, :common_info_path, :report_path
 
@@ -213,7 +216,8 @@ module Publisher
           update_pr: update_pr,
           summary_type: summary_type,
           summary_table_type: summary_table_type,
-          collapse_summary: collapse_summary
+          collapse_summary: collapse_summary,
+          unresolved_discussion_on_failure: unresolved_discussion_on_failure
         )
       end
 

--- a/spec/allure_report_publisher/commands/common_uploader_command.rb
+++ b/spec/allure_report_publisher/commands/common_uploader_command.rb
@@ -33,6 +33,7 @@ RSpec.shared_examples "upload command" do
       copy_latest: false,
       summary_type: nil,
       collapse_summary: false,
+      unresolved_discussion_on_failure: false,
       summary_table_type: :ascii
     }
   end
@@ -63,7 +64,8 @@ RSpec.shared_examples "upload command" do
             :update_pr,
             :summary_type,
             :summary_table_type,
-            :collapse_summary
+            :collapse_summary,
+            :unresolved_discussion_on_failure
           )
         )
         expect(uploader_stub).to have_received(:generate_report)

--- a/spec/allure_report_publisher/lib/providers/common_provider.rb
+++ b/spec/allure_report_publisher/lib/providers/common_provider.rb
@@ -14,7 +14,8 @@ RSpec.shared_context "with provider helper" do
     instance_double(
       Publisher::Helpers::UrlSectionBuilder,
       updated_pr_description: updated_pr_description,
-      comment_body: updated_comment_body
+      comment_body: updated_comment_body,
+      summary_has_failures?: false
     )
   end
 

--- a/spec/allure_report_publisher/lib/providers/common_provider.rb
+++ b/spec/allure_report_publisher/lib/providers/common_provider.rb
@@ -15,8 +15,7 @@ RSpec.shared_context "with provider helper" do
     instance_double(
       Publisher::Helpers::UrlSectionBuilder,
       updated_pr_description: updated_pr_description,
-      comment_body: updated_comment_body,
-      summary_has_failures?: false
+      comment_body: updated_comment_body
     )
   end
 

--- a/spec/allure_report_publisher/lib/providers/common_provider.rb
+++ b/spec/allure_report_publisher/lib/providers/common_provider.rb
@@ -6,7 +6,8 @@ RSpec.shared_context "with provider helper" do
       update_pr: update_pr,
       summary_type: summary_type,
       summary_table_type: summary_table_type,
-      collapse_summary: collapse_summary
+      collapse_summary: collapse_summary,
+      unresolved_discussion_on_failure: unresolved_discussion_on_failure
     )
   end
 
@@ -30,6 +31,7 @@ RSpec.shared_context "with provider helper" do
   let(:summary_type) { nil }
   let(:summary_table_type) { nil }
   let(:collapse_summary) { false }
+  let(:unresolved_discussion_on_failure) { false }
 
   before do
     allow(Publisher::Helpers::UrlSectionBuilder).to receive(:new)

--- a/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
+++ b/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
@@ -119,10 +119,6 @@ RSpec.describe Publisher::Providers::Gitlab, epic: "providers" do
           double("note", id: note_id, body: "existing comment")
         end
 
-        let(:existing_alert_note) do
-          double("alert note", id: note_id, body: alert_comment_text)
-        end
-
         let(:discussion) do
           double("comment", id: comment_id, body: "existing comment", notes: [note])
         end

--- a/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
+++ b/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
@@ -106,19 +106,14 @@ RSpec.describe Publisher::Providers::Gitlab, epic: "providers" do
       context "when there are test failures in summary" do
         before do
           allow(Publisher::Helpers::UrlSectionBuilder).to receive(:match?)
-            .with(discussion.body)
-            .and_return(true)
-          allow(url_builder).to receive(:summary_has_failures?)
+            .with(any_args)
             .and_return(true)
         end
 
         let(:unresolved_discussion_on_failure) { true }
         let(:alert_comment_text) { "There are some test failures that need attention" }
         let(:comment_id) { 2 }
-        let(:note_id) { "abc" }
-        let(:note) do
-          double("note", id: note_id, body: "existing comment")
-        end
+        let(:note) { double("note", id: "abc", body: "existing comment ❌") }
 
         let(:discussion) do
           double("comment", id: comment_id, body: "existing comment", notes: [note])

--- a/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
+++ b/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe Publisher::Providers::Gitlab, epic: "providers" do
       merge_request_discussions: comment_double,
       update_merge_request: nil,
       create_merge_request_discussion: nil,
-      update_merge_request_discussion_note: nil,
       create_merge_request_discussion_note: nil,
       create_merge_request_comment: nil,
-      delete_merge_request_discussion_note: nil
+      delete_merge_request_discussion_note: nil,
+      edit_merge_request_note: nil
     )
   end
 
@@ -112,6 +112,7 @@ RSpec.describe Publisher::Providers::Gitlab, epic: "providers" do
             .and_return(true)
         end
 
+        let(:unresolved_discussion_on_failure) { true }
         let(:alert_comment_text) { "There are some test failures that need attention" }
         let(:comment_id) { 2 }
         let(:note_id) { "abc" }
@@ -186,8 +187,8 @@ RSpec.describe Publisher::Providers::Gitlab, epic: "providers" do
 
           expect(url_builder).to have_received(:comment_body)
             .with(discussion.body)
-          expect(client).to have_received(:update_merge_request_discussion_note)
-            .with(project, mr_id, comment_id, note_id, body: updated_comment_body)
+          expect(client).to have_received(:edit_merge_request_note)
+            .with(project, mr_id, note_id, updated_comment_body)
         end
       end
     end


### PR DESCRIPTION
* Check the current summary comment to see if there are any failures. If so, add a failure alert comment that must be resolved. If not, remove any existing failure alert comments.