### PR TITLE
Do not remove alert comment when  there are failures

### DIFF
--- a/lib/allure_report_publisher/lib/providers/gitlab.rb
+++ b/lib/allure_report_publisher/lib/providers/gitlab.rb
@@ -58,7 +58,7 @@ module Publisher
         )
       end
 
-      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/PerceivedComplexity
       # Add comment with report url
       #
       # @return [void]
@@ -79,13 +79,21 @@ module Publisher
 
         @discussion = nil
 
-        if unresolved_discussion_on_failure && main_comment&.body&.include?("❌") && !alert_comment
+        if unresolved_discussion_on_failure && report_has_failures? && !alert_comment
           client.create_merge_request_discussion_note(project, mr_iid, discussion.id, body: alert_comment_text)
-        elsif alert_comment && !main_comment&.body&.include?("❌")
+        elsif alert_comment && !report_has_failures?
           client.delete_merge_request_discussion_note(project, mr_iid, discussion.id, alert_comment.id)
         end
       end
-      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+      # Check if allure report has failures
+      #
+      # @return [Boolean]
+      def report_has_failures?
+        main_comment&.body&.include?("❌")
+      end
+
+      # rubocop:enable Metrics/PerceivedComplexity
 
       # Existing discussion that has comment with allure urls
       #

--- a/lib/allure_report_publisher/lib/providers/gitlab.rb
+++ b/lib/allure_report_publisher/lib/providers/gitlab.rb
@@ -81,7 +81,7 @@ module Publisher
 
         if unresolved_discussion_on_failure && main_comment&.body&.include?("❌") && !alert_comment
           client.create_merge_request_discussion_note(project, mr_iid, discussion.id, body: alert_comment_text)
-        elsif alert_comment
+        elsif alert_comment && !main_comment&.body&.include?("❌")
           client.delete_merge_request_discussion_note(project, mr_iid, discussion.id, alert_comment.id)
         end
       end

--- a/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
+++ b/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Publisher::Providers::Gitlab, epic: "providers" do
         end
       end
 
-      context "with alert comment exists and no ❌ in main comment" do
+      context "when alert comment exists and no ❌ in main comment" do
         let(:discussion_id) { 2 }
         let(:alert_note_id) { "def" }
 
@@ -193,7 +193,7 @@ RSpec.describe Publisher::Providers::Gitlab, epic: "providers" do
         end
       end
 
-      context "with alert comment exists and ❌ in main comment" do
+      context "when alert comment exists and ❌ in main comment" do
         let(:discussion) do
           double("comment", id: 2, notes: [main_comment, existing_alert_note])
         end
@@ -214,7 +214,7 @@ RSpec.describe Publisher::Providers::Gitlab, epic: "providers" do
           allow(provider).to receive(:alert_comment).and_return(existing_alert_note)
         end
 
-        it "removes the alert comment" do
+        it "does not remove the alert comment" do
           provider.add_result_summary
 
           expect(client).not_to have_received(:delete_merge_request_discussion_note)

--- a/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
+++ b/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
@@ -103,6 +103,33 @@ RSpec.describe Publisher::Providers::Gitlab, epic: "providers" do
         end
       end
 
+      context "when there are no test failures in summary" do
+        before do
+          allow(Publisher::Helpers::UrlSectionBuilder).to receive(:match?)
+            .with(any_args)
+            .and_return(true)
+        end
+
+        let(:unresolved_discussion_on_failure) { true }
+        let(:discussion) do
+          double("comment", id: 2, notes: [main_comment])
+        end
+
+        let(:main_comment) do
+          double("main comment", id: "abc", body: "Allure report body")
+        end
+
+        let(:existing_alert_note) do
+          double("alert note", id: "def", body: "There are some test failures that need attention")
+        end
+
+        it "does not add a resolvable attention comment" do
+          provider.add_result_summary
+
+          expect(client).not_to have_received(:create_merge_request_discussion_note)
+        end
+      end
+
       context "when there are test failures in summary" do
         before do
           allow(Publisher::Helpers::UrlSectionBuilder).to receive(:match?)
@@ -111,42 +138,48 @@ RSpec.describe Publisher::Providers::Gitlab, epic: "providers" do
         end
 
         let(:unresolved_discussion_on_failure) { true }
-        let(:alert_comment_text) { "There are some test failures that need attention" }
-        let(:comment_id) { 2 }
-        let(:note) { double("note", id: "abc", body: "existing comment ❌") }
 
+        let(:discussion_id) { 2 }
+        let(:alert_comment_text) { "There are some test failures that need attention" }
         let(:discussion) do
-          double("comment", id: comment_id, body: "existing comment", notes: [note])
+          double("comment", id: discussion_id, notes: [main_comment])
+        end
+
+        let(:main_comment) do
+          double("main comment", id: "abc", body: "Allure report body with ❌")
+        end
+
+        let(:existing_alert_note) do
+          double("alert note", id: "def", body: alert_comment_text)
         end
 
         it "adds a resolvable attention comment" do
           provider.add_result_summary
 
           expect(client).to have_received(:create_merge_request_discussion_note)
-            .with(project, mr_id, comment_id, body: alert_comment_text)
+            .with(project, mr_id, discussion_id, body: alert_comment_text)
         end
       end
 
-      context "with existing alert comment" do
-        let(:comment_id) { 2 }
-        let(:note_id) { "abc" }
-        let(:note) do
-          double("note", id: note_id, body: "existing comment")
-        end
+      context "with alert comment exists and no ❌ in main comment" do
+        let(:discussion_id) { 2 }
+        let(:alert_note_id) { "def" }
 
         let(:discussion) do
-          double("comment", id: comment_id, body: "existing comment", notes: [note])
+          double("comment", id: discussion_id, notes: [main_comment, existing_alert_note])
         end
 
-        let(:alert_comment_text) { "There are some test failures that need attention" }
+        let(:main_comment) do
+          double("main comment", id: "abc", body: "Allure report body")
+        end
 
         let(:existing_alert_note) do
-          double("alert note", id: note_id, body: alert_comment_text)
+          double("alert note", id: alert_note_id, body: "There are some test failures that need attention")
         end
 
         before do
           allow(Publisher::Helpers::UrlSectionBuilder).to receive(:match?)
-            .with(discussion.body)
+            .with(any_args)
             .and_return(true)
 
           allow(provider).to receive(:alert_comment).and_return(existing_alert_note)
@@ -156,7 +189,35 @@ RSpec.describe Publisher::Providers::Gitlab, epic: "providers" do
           provider.add_result_summary
 
           expect(client).to have_received(:delete_merge_request_discussion_note)
-            .with(project, mr_id, comment_id, note_id)
+            .with(project, mr_id, discussion_id, alert_note_id)
+        end
+      end
+
+      context "with alert comment exists and ❌ in main comment" do
+        let(:discussion) do
+          double("comment", id: 2, notes: [main_comment, existing_alert_note])
+        end
+
+        let(:main_comment) do
+          double("main comment", id: "abc", body: "Allure report body with ❌")
+        end
+
+        let(:existing_alert_note) do
+          double("alert note", id: "def", body: "There are some test failures that need attention")
+        end
+
+        before do
+          allow(Publisher::Helpers::UrlSectionBuilder).to receive(:match?)
+            .with(any_args)
+            .and_return(true)
+
+          allow(provider).to receive(:alert_comment).and_return(existing_alert_note)
+        end
+
+        it "removes the alert comment" do
+          provider.add_result_summary
+
+          expect(client).not_to have_received(:delete_merge_request_discussion_note)
         end
       end
 


### PR DESCRIPTION
I noticed an issue where if an alert comment already existed and there were failures, subsequent posts would remove the alert comment. This ~~MR~~ PR fixes that issue and updates unit tests.