### PR TITLE
Use octet-stream content type as default for s3 uploads

### DIFF
--- a/lib/allure_report_publisher/lib/uploaders/s3.rb
+++ b/lib/allure_report_publisher/lib/uploaders/s3.rb
@@ -99,7 +99,7 @@ module Publisher
             copy_source: "/#{bucket_name}/#{key(full_prefix, file.relative_path_from(report_path))}",
             key: key(prefix, file.relative_path_from(report_path)),
             metadata_directive: "REPLACE",
-            content_type: MiniMime.lookup_by_filename(file).content_type,
+            content_type: content_type(file),
             cache_control: "max-age=60"
           }
         end
@@ -142,6 +142,18 @@ module Publisher
       # @return [String]
       def url(path_prefix)
         [base_url || "http://#{bucket_name}.s3.amazonaws.com", path_prefix, "index.html"].compact.join("/")
+      end
+
+      # Get file content type
+      #
+      # @param [Pathname] file
+      # @return [String]
+      def content_type(file)
+        c_type = MiniMime.lookup_by_filename(file)&.content_type
+        return c_type if c_type
+
+        log_debug("Content type for '#{file}' not found, using default 'application/octet-stream'")
+        "application/octet-stream"
       end
     end
   end


### PR DESCRIPTION
Fixes: https://github.com/andrcuns/allure-report-publisher/issues/489

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/497/merge/5191482556/index.html) for [1689d0d4](https://github.com/andrcuns/allure-report-publisher/pull/497/commits/1689d0d4bcaacad83a0e4e86e4e175e62425e17a)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| commands  | 75     | 0      | 0       | 0     | 75    | ✅     |
| providers | 60     | 0      | 0       | 0     | 60    | ✅     |
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
| helpers   | 123    | 0      | 0       | 0     | 123   | ✅     |
| uploaders | 57     | 0      | 0       | 0     | 57    | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 324    | 0      | 0       | 0     | 324   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->