### PR TITLE
Fix missing report urls in history tab

### DIFF
--- a/lib/allure_report_publisher/lib/report_generator.rb
+++ b/lib/allure_report_publisher/lib/report_generator.rb
@@ -53,8 +53,24 @@ module Publisher
       cmd = "allure generate --clean --output #{report_path} #{common_info_path} #{result_paths}"
       out = execute_shell(cmd)
       log_debug("Generated allure report. #{out}")
+
+      deduplicate_executors
     rescue StandardError => e
       raise(AllureError, e.message)
+    end
+
+    # Remove duplicate entries from executors widget
+    # This is a workaround for making history work with multiple result paths
+    # allure-report requires executors.json in every results folder but it will create duplicate entries
+    # in executors widget of the final report
+    #
+    # @return [void]
+    def deduplicate_executors
+      executors_file = File.join(report_path, "widgets", "executors.json")
+      executors_json = JSON.parse(File.read(executors_file)).uniq
+
+      log_debug("Removing duplicate entries in '#{executors_file}'")
+      File.write(executors_file, JSON.generate(executors_json))
     end
   end
 end

--- a/lib/allure_report_publisher/lib/report_generator.rb
+++ b/lib/allure_report_publisher/lib/report_generator.rb
@@ -52,7 +52,7 @@ module Publisher
       log_debug("Generating allure report")
       cmd = "allure generate --clean --output #{report_path} #{common_info_path} #{result_paths}"
       out = execute_shell(cmd)
-      log_debug("Generated allure report. #{out}")
+      log_debug("Generated allure report. #{out}".strip)
 
       deduplicate_executors
     rescue StandardError => e

--- a/lib/allure_report_publisher/lib/uploaders/_uploader.rb
+++ b/lib/allure_report_publisher/lib/uploaders/_uploader.rb
@@ -238,11 +238,16 @@ module Publisher
       def add_executor_info
         return unless ci_provider
 
-        json_path = "#{common_info_path}/#{EXECUTOR_JSON}"
         json = ci_provider.executor_info.to_json
-        log_debug("Saving ci executor info")
-        File.write(json_path, json)
-        log_debug("Saved '#{EXECUTOR_JSON}' as '#{json_path}'\n#{JSON.pretty_generate(ci_provider.executor_info)}")
+        log_debug("Saving ci executor info:\n#{JSON.pretty_generate(ci_provider.executor_info)}")
+        # allure-report will fail to pick up reportUrl in history tab if executor.json is not present alongside results
+        [common_info_path, *result_paths].each do |path|
+          file = File.join(path, EXECUTOR_JSON)
+          next log_debug("Skipping '#{file}', executor info already exists") if File.exist?(file)
+
+          File.write(File.join(path, EXECUTOR_JSON), json)
+          log_debug("Saved ci executor info to '#{file}'")
+        end
       end
 
       # Fetch allure report history

--- a/spec/allure_report_publisher/lib/report_generator_spec.rb
+++ b/spec/allure_report_publisher/lib/report_generator_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe Publisher::ReportGenerator, epic: "generator" do
   end
 
   context "with present allure results" do
+    let(:executors) { File.read("spec/fixture/fake_report/widgets/executors.json") }
+    let(:deduped_executors) { [JSON.parse(executors).first].to_json }
+
+    before do
+      allow(File).to receive(:read).with("#{report_dir}/widgets/executors.json").and_return(executors)
+      allow(File).to receive(:write).with("#{report_dir}/widgets/executors.json", deduped_executors)
+    end
+
     it "generates allure report" do
       freeze_time do
         report_generator.generate
@@ -30,6 +38,7 @@ RSpec.describe Publisher::ReportGenerator, epic: "generator" do
         expect(Open3).to have_received(:capture3).with(
           "allure generate --clean --output #{report_dir} #{common_info_dir} #{result_paths.join(' ')}"
         )
+        expect(File).to have_received(:write).with("#{report_dir}/widgets/executors.json", deduped_executors)
       end
     end
   end

--- a/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
 
     it "adds executor info" do
       described_class.new(**args).execute
-      expect(File).to have_received(:write).with("#{common_info_path}/executor.json", executor_info.to_json)
+      expect(File).to have_received(:write).with("#{common_info_path}/executor.json", executor_info.to_json).twice
     end
 
     it "updates pr description with allure report link" do

--- a/spec/allure_report_publisher/lib/uploaders/s3_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/s3_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Publisher::Uploaders::S3, epic: "uploaders" do
 
     it "adds executor info" do
       described_class.new(**args).execute
-      expect(File).to have_received(:write).with("#{common_info_path}/executor.json", executor_info.to_json)
+      expect(File).to have_received(:write).with("#{common_info_path}/executor.json", executor_info.to_json).twice
     end
 
     it "updates pr description with allure report link" do

--- a/spec/fixture/fake_report/widgets/executors.json
+++ b/spec/fixture/fake_report/widgets/executors.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Github",
+    "type": "github",
+    "url": "https://github.com",
+    "buildOrder": 6681936678,
+    "buildName": "rspec",
+    "buildUrl": "https://github.com/andrcuns/allure-report-publisher/actions/runs/6681936678",
+    "reportName": "AllureReport",
+    "reportUrl": "https://storage.googleapis.com/allure-test-reports/allure-report-publisher/refs/pull/571/merge/6681936678/index.html"
+  },
+  {
+    "name": "Github",
+    "type": "github",
+    "url": "https://github.com",
+    "buildOrder": 6681936678,
+    "buildName": "rspec",
+    "buildUrl": "https://github.com/andrcuns/allure-report-publisher/actions/runs/6681936678",
+    "reportName": "AllureReport",
+    "reportUrl": "https://storage.googleapis.com/allure-test-reports/allure-report-publisher/refs/pull/571/merge/6681936678/index.html"
+  }
+]


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/571/merge/6682203479/index.html) for [9dd81d1c](https://github.com/andrcuns/allure-report-publisher/pull/571/commits/9dd81d1c72a0cb11a8bcc83668d2da43d4cceee0)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| helpers   | 123    | 0      | 0       | 0     | 123   | ✅     |
| uploaders | 57     | 0      | 0       | 0     | 57    | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| providers | 60     | 0      | 0       | 0     | 60    | ✅     |
| commands  | 75     | 0      | 0       | 0     | 75    | ✅     |
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 324    | 0      | 0       | 0     | 324   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->