### PR TITLE
Add renovate for allure-report version management

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,17 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0 12 * * *"
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.6.0
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v39.1.0
+        with:
+          configurationFile: renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": [
+    "regex"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "Dockerfile"
+      ],
+      "matchStrings": [
+        "ARG ALLURE_VERSION=(?<currentValue>.*?)\\n"
+      ],
+      "depNameTemplate": "allure-framework/allure2",
+      "datasourceTemplate": "github-releases"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/573/merge/6682303144/index.html) for [7d55c2e2](https://github.com/andrcuns/allure-report-publisher/pull/573/commits/7d55c2e20c0019dc2956c9927749b5a28d05d69e)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
| helpers   | 123    | 0      | 0       | 0     | 123   | ✅     |
| providers | 60     | 0      | 0       | 0     | 60    | ✅     |
| uploaders | 57     | 0      | 0       | 0     | 57    | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| commands  | 75     | 0      | 0       | 0     | 75    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 324    | 0      | 0       | 0     | 324   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->