### PR TITLE
Fix incorrect validation of sumary table type environment variable

### DIFF
--- a/lib/allure_report_publisher/lib/parser.rb
+++ b/lib/allure_report_publisher/lib/parser.rb
@@ -44,14 +44,20 @@ module Dry
           end.compact
         end
 
-        def option_from_env(option) # rubocop:disable Metrics/CyclomaticComplexity
+        def option_from_env(option)
           name = "ALLURE_REPORT_#{option.name.to_s.upcase}"
           value = ENV[name]
           return if value.nil? || value.empty?
           return if option.boolean? && !%w[true false].include?(value)
-          raise(InvalidEnvValue, "#{name} contains invalid value: '#{value}'") if option.values&.none?(value)
 
+          validate_accepted_values(option, value)
           option.boolean? ? value == "true" : value
+        end
+
+        def validate_accepted_values(option, value)
+          return unless option.values&.none? { |v| v.to_s == value }
+
+          raise(InvalidEnvValue, "#{name} contains invalid value: '#{value}'")
         end
       end
     end


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/578/merge/6731795088/index.html) for [650475e4](https://github.com/andrcuns/allure-report-publisher/pull/578/commits/650475e47d336501fda18c63cac2dc365d5c6b68)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
| providers | 60     | 0      | 0       | 0     | 60    | ✅     |
| commands  | 93     | 0      | 0       | 0     | 93    | ✅     |
| helpers   | 123    | 0      | 0       | 0     | 123   | ✅     |
| uploaders | 57     | 0      | 0       | 0     | 57    | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 342    | 0      | 0       | 0     | 342   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->