### PR TITLE
[BREAKING] Use same environment variable prefix for all options

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Examples:
 
 ## Environment variables
 
-All named options can be configured via environment variables. Environment variables are prefixed with `ALLURE_REPORT_` and uppercased.
+All named options can be configured via environment variables. Environment variables are prefixed with `ALLURE_` and uppercased.
 
 Example: `--results-glob` can be configured via `ALLURE_REPORT_RESULTS_GLOB`
 

--- a/lib/allure_report_publisher/lib/parser.rb
+++ b/lib/allure_report_publisher/lib/parser.rb
@@ -5,6 +5,8 @@ module Dry
     module Parser
       class InvalidEnvValue < StandardError; end
 
+      ENV_VAR_PREFIX = "ALLURE_".freeze
+
       class << self
         def call(command, arguments, prog_name)
           original_arguments = arguments.dup
@@ -45,7 +47,7 @@ module Dry
         end
 
         def option_from_env(option)
-          name = "ALLURE_REPORT_#{option.name.to_s.upcase}"
+          name = "#{ENV_VAR_PREFIX}#{option.name.to_s.upcase}"
           value = ENV[name]
           return if value.nil? || value.empty?
           return if option.boolean? && !%w[true false].include?(value)

--- a/spec/allure_report_publisher/commands/common_uploader_command.rb
+++ b/spec/allure_report_publisher/commands/common_uploader_command.rb
@@ -148,7 +148,7 @@ RSpec.shared_examples "upload command" do
     end
 
     context "with valid arguments" do
-      let(:env) { { ALLURE_REPORT_UPDATE_PR: "comment" } }
+      let(:env) { { ALLURE_UPDATE_PR: "comment" } }
 
       it "fetches option from environment variable" do
         run_cli(*command, *cli_args)
@@ -158,7 +158,7 @@ RSpec.shared_examples "upload command" do
     end
 
     context "with boolean type arguments" do
-      let(:env) { { ALLURE_REPORT_COPY_LATEST: "true" } }
+      let(:env) { { ALLURE_COPY_LATEST: "true" } }
 
       it "correctly casts boolean type argument" do
         run_cli(*command, *cli_args)
@@ -168,7 +168,7 @@ RSpec.shared_examples "upload command" do
     end
 
     context "with invalid arguments" do
-      let(:env) { { ALLURE_REPORT_UPDATE_PR: "bla" } }
+      let(:env) { { ALLURE_UPDATE_PR: "bla" } }
 
       it "exits when environment variable contains invalid value" do
         expect { run_cli(*command, *cli_args) }.to raise_error(SystemExit)


### PR DESCRIPTION
Use `ALLURE_` prefix instead of `ALLURE_REPORT_` prefix for cli options to keep things consistent

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/580/merge/6756218541/index.html) for [8fb0e0bf](https://github.com/andrcuns/allure-report-publisher/pull/580/commits/8fb0e0bfd38b03789f41b2294a02d0c52e9b8b39)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| providers | 60     | 0      | 0       | 0     | 60    | ✅     |
| helpers   | 123    | 0      | 0       | 0     | 123   | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| uploaders | 57     | 0      | 0       | 0     | 57    | ✅     |
| commands  | 93     | 0      | 0       | 0     | 93    | ✅     |
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 342    | 0      | 0       | 0     | 342   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->