### PR TITLE
Bump openjdk and alpine versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.2-alpine3.17 as ruby
+FROM ruby:3.2.2-alpine3.18 as ruby
 
 ARG GEMFILE=allure-report-publisher.gem
 
@@ -27,7 +27,7 @@ FROM ruby as production
 # Install allure
 ARG ALLURE_VERSION=2.24.1
 ENV PATH=$PATH:/usr/local/allure-${ALLURE_VERSION}/bin
-RUN apk --no-cache add openjdk20 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN apk --no-cache add openjdk21 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN set -eux; \
     wget -O allure.tgz https://github.com/allure-framework/allure2/releases/download/${ALLURE_VERSION}/allure-${ALLURE_VERSION}.tgz; \
     tar -xzf allure.tgz -C /usr/local && rm allure.tgz; \


### PR DESCRIPTION
* Bump openjdk to v21
* Bump alpine to v3.18

<!-- allure -->
---
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/585/merge/6922036284/index.html) for [07c173f7](https://github.com/andrcuns/allure-report-publisher/pull/585/commits/07c173f79055a5fac453ff171b3aa2d7f48885a6)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| commands  | 93     | 0      | 0       | 0     | 93    | ✅     |
| providers | 60     | 0      | 0       | 0     | 60    | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| helpers   | 123    | 0      | 0       | 0     | 123   | ✅     |
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
| uploaders | 57     | 0      | 0       | 0     | 57    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 342    | 0      | 0       | 0     | 342   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->