### PR TITLE
Remove deprecated set-output usage from workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,9 @@ jobs:
         id: images
         run: |
           if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
-            echo "::set-output name=images::andrcuns/allure-report-publisher,ghcr.io/andrcuns/allure-report-publisher"
+            echo "{images}={andrcuns/allure-report-publisher,ghcr.io/andrcuns/allure-report-publisher}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=images::ghcr.io/andrcuns/allure-report-publisher"
+            echo "{images}={ghcr.io/andrcuns/allure-report-publisher}" >> $GITHUB_OUTPUT
           fi
       - name: Docker tags
         id: tags


### PR DESCRIPTION
<!-- allure -->
# Allure report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/586/merge/6922129213/index.html) for [7814f508](https://github.com/andrcuns/allure-report-publisher/pull/586/commits/7814f508456ecfd747504358050e0bc375a229fe)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| uploaders | 57     | 0      | 0       | 0     | 57    | ✅     |
| providers | 60     | 0      | 0       | 0     | 60    | ✅     |
| helpers   | 123    | 0      | 0       | 0     | 123   | ✅     |
| commands  | 93     | 0      | 0       | 0     | 93    | ✅     |
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 342    | 0      | 0       | 0     | 342   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->