### PR TITLE
Add option to set custom title for pr/comment description section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Options:
   --bucket=VALUE                    # Bucket name. Required: true
   --prefix=VALUE                    # Optional prefix for report path. Required: false
   --update-pr=VALUE                 # Add report url to PR via comment or description update. Required: false: (comment/description/actions)
+  --report-title=VALUE              # Title for url section in PR comment/description. Required: false, default: "Allure Report"
   --summary=VALUE                   # Additionally add summary table to PR comment or description. Required: false: (behaviors/suites/packages/total)
   --summary-table-type=VALUE        # Summary table type. Required: false: (ascii/markdown), default: :ascii
   --base-url=VALUE                  # Use custom base url instead of default cloud provider one. Required: false

--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -113,7 +113,8 @@ module Publisher
             :update_pr,
             :collapse_summary,
             :summary_table_type,
-            :unresolved_discussion_on_failure
+            :unresolved_discussion_on_failure,
+            :report_title
           )
         )
       end

--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -25,6 +25,10 @@ module Publisher
              type: :string,
              desc: "Add report url to PR via comment or description update. Required: false",
              values: %w[comment description actions]
+      option :report_title,
+             type: :string,
+             default: "Allure Report",
+             desc: "Title for url section in PR comment/description. Required: false"
       option :summary,
              type: :string,
              desc: "Additionally add summary table to PR comment or description. Required: false",

--- a/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
+++ b/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
@@ -14,6 +14,7 @@ module Publisher
       # @param [String] sha_url
       # @param [String] summary_type
       # @param [String] collapse_summary
+      # @param [String] report_title
       def initialize(**args)
         @report_url = args[:report_url]
         @report_path = args[:report_path]
@@ -22,6 +23,7 @@ module Publisher
         @summary_type = args[:summary_type]
         @summary_table_type = args[:summary_table_type]
         @collapse_summary = args[:collapse_summary]
+        @report_title = args[:report_title]
       end
 
       # Matches url section pattern
@@ -64,7 +66,8 @@ module Publisher
                   :sha_url,
                   :summary_type,
                   :summary_table_type,
-                  :collapse_summary
+                  :collapse_summary,
+                  :report_title
 
       private
 
@@ -72,7 +75,7 @@ module Publisher
       #
       # @return [String]
       def heading
-        @heading ||= "# Allure report\n`allure-report-publisher` generated test report!"
+        @heading ||= "# #{report_title}\n`allure-report-publisher` generated test report!"
       end
 
       # Test run summary

--- a/lib/allure_report_publisher/lib/providers/_provider.rb
+++ b/lib/allure_report_publisher/lib/providers/_provider.rb
@@ -34,6 +34,7 @@ module Publisher
         @summary_table_type = args[:summary_table_type]
         @collapse_summary = args[:collapse_summary]
         @unresolved_discussion_on_failure = args[:unresolved_discussion_on_failure]
+        @report_title = args[:report_title]
       end
 
       # :nocov:
@@ -80,7 +81,8 @@ module Publisher
                   :summary_type,
                   :collapse_summary,
                   :summary_table_type,
-                  :unresolved_discussion_on_failure
+                  :unresolved_discussion_on_failure,
+                  :report_title
 
       # Current pull request description
       #
@@ -143,7 +145,8 @@ module Publisher
           sha_url: sha_url,
           summary_type: summary_type,
           summary_table_type: summary_table_type,
-          collapse_summary: collapse_summary
+          collapse_summary: collapse_summary,
+          report_title: report_title
         )
       end
     end

--- a/lib/allure_report_publisher/lib/uploaders/_uploader.rb
+++ b/lib/allure_report_publisher/lib/uploaders/_uploader.rb
@@ -35,6 +35,7 @@ module Publisher
       # @option args [Boolean] :collapse_summary
       # @option args [Boolean] :unresolved_discussion_on_failure
       # @option args [String] :copy_latest
+      # @option args [String] :report_title
       def initialize(**args)
         @result_paths = args[:result_paths]
         @bucket_name = args[:bucket]
@@ -46,6 +47,7 @@ module Publisher
         @copy_latest = Providers.provider && args[:copy_latest] # copy latest for ci only
         @collapse_summary = args[:collapse_summary]
         @unresolved_discussion_on_failure = args[:unresolved_discussion_on_failure]
+        @report_title = args[:report_title]
       end
 
       # Execute allure report generation and upload
@@ -114,7 +116,8 @@ module Publisher
                   :summary_type,
                   :collapse_summary,
                   :summary_table_type,
-                  :unresolved_discussion_on_failure
+                  :unresolved_discussion_on_failure,
+                  :report_title
 
       def_delegators :report_generator, :common_info_path, :report_path
 
@@ -217,7 +220,8 @@ module Publisher
           summary_type: summary_type,
           summary_table_type: summary_table_type,
           collapse_summary: collapse_summary,
-          unresolved_discussion_on_failure: unresolved_discussion_on_failure
+          unresolved_discussion_on_failure: unresolved_discussion_on_failure,
+          report_title: report_title
         )
       end
 

--- a/spec/allure_report_publisher/commands/common_uploader_command.rb
+++ b/spec/allure_report_publisher/commands/common_uploader_command.rb
@@ -87,6 +87,14 @@ RSpec.shared_examples "upload command" do
       expect(uploader_stub).to have_received(:add_result_summary)
     end
 
+    it "executes uploader with --report-title=title" do
+      run_cli(*command, *cli_args, "--report-title=custom title")
+
+      expect(uploader).to have_received(:new).with({ **args, report_title: "custom title" })
+      expect(uploader_stub).to have_received(:generate_report)
+      expect(uploader_stub).to have_received(:upload)
+    end
+
     it "executes uploader with --update-pr=description" do
       run_cli(*command, *cli_args, "--update-pr=description")
 

--- a/spec/allure_report_publisher/commands/common_uploader_command.rb
+++ b/spec/allure_report_publisher/commands/common_uploader_command.rb
@@ -6,6 +6,7 @@ RSpec.shared_examples "upload command" do
   let(:result_paths) { [result_glob] }
   let(:bucket) { "bucket" }
   let(:prefix) { "my-project/prs" }
+  let(:report_title) { "Allure Report" }
   let(:uploader_stub) do
     instance_double(
       uploader.to_s,
@@ -34,7 +35,8 @@ RSpec.shared_examples "upload command" do
       summary_type: nil,
       collapse_summary: false,
       unresolved_discussion_on_failure: false,
-      summary_table_type: :ascii
+      summary_table_type: :ascii,
+      report_title: report_title
     }
   end
 
@@ -65,7 +67,8 @@ RSpec.shared_examples "upload command" do
             :summary_type,
             :summary_table_type,
             :collapse_summary,
-            :unresolved_discussion_on_failure
+            :unresolved_discussion_on_failure,
+            :report_title
           )
         )
         expect(uploader_stub).to have_received(:generate_report)

--- a/spec/allure_report_publisher/helpers/url_section_builder_spec.rb
+++ b/spec/allure_report_publisher/helpers/url_section_builder_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Publisher::Helpers::UrlSectionBuilder, epic: "helpers" do
       build_name: build_name,
       sha_url: sha_url,
       summary_type: summary_type,
-      collapse_summary: collapse_summary
+      collapse_summary: collapse_summary,
+      report_title: report_title
     )
   end
 
@@ -18,6 +19,7 @@ RSpec.describe Publisher::Helpers::UrlSectionBuilder, epic: "helpers" do
   let(:build_name) { "build-name" }
   let(:sha_url) { "sha-url" }
   let(:report_path) { "report_path" }
+  let(:report_title) { "Report title" }
   let(:status) { "✅" }
   let(:summary_type) { nil }
   let(:collapse_summary) { false }
@@ -53,7 +55,7 @@ RSpec.describe Publisher::Helpers::UrlSectionBuilder, epic: "helpers" do
     <<~URLS.strip
       <!-- allure -->
       ---
-      # Allure report
+      # #{report_title}
       `allure-report-publisher` generated test report!
 
       <!-- jobs -->

--- a/spec/allure_report_publisher/lib/providers/common_provider.rb
+++ b/spec/allure_report_publisher/lib/providers/common_provider.rb
@@ -7,7 +7,8 @@ RSpec.shared_context "with provider helper" do
       summary_type: summary_type,
       summary_table_type: summary_table_type,
       collapse_summary: collapse_summary,
-      unresolved_discussion_on_failure: unresolved_discussion_on_failure
+      unresolved_discussion_on_failure: unresolved_discussion_on_failure,
+      report_title: report_title
     )
   end
 
@@ -31,6 +32,7 @@ RSpec.shared_context "with provider helper" do
   let(:summary_table_type) { nil }
   let(:collapse_summary) { false }
   let(:unresolved_discussion_on_failure) { false }
+  let(:report_title) { "Report title" }
 
   before do
     allow(Publisher::Helpers::UrlSectionBuilder).to receive(:new)
@@ -41,7 +43,8 @@ RSpec.shared_context "with provider helper" do
         sha_url: sha_url,
         summary_type: summary_type,
         summary_table_type: summary_table_type,
-        collapse_summary: collapse_summary
+        collapse_summary: collapse_summary,
+        report_title: report_title
       )
       .and_return(url_builder)
   end


### PR DESCRIPTION
<!-- allure -->
# Allure Report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/598/merge/7104816363/index.html) for [0d8f48c8](https://github.com/andrcuns/allure-report-publisher/pull/598/commits/0d8f48c828cf67d59035d60a30ac589f33869bd0)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| commands  | 99     | 0      | 0       | 0     | 99    | ✅     |
| uploaders | 57     | 0      | 0       | 0     | 57    | ✅     |
| helpers   | 123    | 0      | 0       | 0     | 123   | ✅     |
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| providers | 60     | 0      | 0       | 0     | 60    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 348    | 0      | 0       | 0     | 348   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->