### PR TITLE
Make flaky status configurable

### DIFF
--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -15,6 +15,7 @@ module Publisher
                values: %w[s3 gcs],
                desc: "Cloud storage type"
 
+      # rubocop:disable Metrics/LineLength
       option :results_glob,
              desc: "Glob pattern to return allure results directories. Required: true"
       option :bucket,
@@ -46,6 +47,10 @@ module Publisher
                Publisher::Helpers::Summary::ASCII,
                Publisher::Helpers::Summary::MARKDOWN
              ]
+      option :flaky_warning_status,
+             type: :boolean,
+             default: false,
+             desc: "Mark run with a '!' status in PR comment/description if report contains flaky tests. Required: false"
       option :base_url,
              type: :string,
              desc: "Use custom base url instead of default cloud provider one. Required: false"
@@ -72,6 +77,7 @@ module Publisher
              type: :boolean,
              default: false,
              desc: "Print additional debug output"
+      # rubocop:enable Metrics/LineLength
 
       example [
         "s3 --results-glob='path/to/allure-results' --bucket=my-bucket",
@@ -117,9 +123,10 @@ module Publisher
           report_path: uploader.report_path,
           summary_type: args[:summary],
           **args.slice(
-            :summary_table_type,
             :update_pr,
             :collapse_summary,
+            :summary_table_type,
+            :flaky_warning_status,
             :unresolved_discussion_on_failure,
             :report_title
           )

--- a/lib/allure_report_publisher/lib/helpers/summary.rb
+++ b/lib/allure_report_publisher/lib/helpers/summary.rb
@@ -17,10 +17,12 @@ module Publisher
       # @param [String] report_path
       # @param [String] summary_type
       # @param [String] markdown
-      def initialize(report_path, summary_type, table_type = ASCII)
+      # @param [Boolean] flaky_warning_status
+      def initialize(report_path, summary_type, table_type = ASCII, flaky_warning_status: false)
         @report_path = report_path
         @summary_type = summary_type || TOTAL
         @table_type = table_type
+        @flaky_warning_status = flaky_warning_status
       end
 
       # Summary table
@@ -51,7 +53,7 @@ module Publisher
 
       private
 
-      attr_reader :report_path, :summary_type, :table_type
+      attr_reader :report_path, :summary_type, :table_type, :flaky_warning_status
 
       # Expanded summary table
       #
@@ -102,7 +104,7 @@ module Publisher
       # @return [String]
       def status_icon(passed, failed, flaky)
         return "➖" if passed.zero? && failed.zero?
-        return flaky.zero? ? "✅" : "❗" if failed.zero?
+        return !flaky_warning_status || flaky.zero? ? "✅" : "❗" if failed.zero?
 
         "❌"
       end

--- a/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
+++ b/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
@@ -14,6 +14,7 @@ module Publisher
       # @param [String] sha_url
       # @param [String] summary_type
       # @param [String] collapse_summary
+      # @param [Boolean] flaky_warning_status
       # @param [String] report_title
       def initialize(**args)
         @report_url = args[:report_url]
@@ -23,6 +24,7 @@ module Publisher
         @summary_type = args[:summary_type]
         @summary_table_type = args[:summary_table_type]
         @collapse_summary = args[:collapse_summary]
+        @flaky_warning_status = args[:flaky_warning_status]
         @report_title = args[:report_title]
       end
 
@@ -67,6 +69,7 @@ module Publisher
                   :summary_type,
                   :summary_table_type,
                   :collapse_summary,
+                  :flaky_warning_status,
                   :report_title
 
       private
@@ -82,7 +85,12 @@ module Publisher
       #
       # @return [Helpers::Summary]
       def summary
-        @summary ||= Helpers::Summary.new(report_path, summary_type, summary_table_type)
+        @summary ||= Helpers::Summary.new(
+          report_path,
+          summary_type,
+          summary_table_type,
+          flaky_warning_status: flaky_warning_status
+        )
       end
 
       # Single job report URL entry

--- a/lib/allure_report_publisher/lib/providers/_provider.rb
+++ b/lib/allure_report_publisher/lib/providers/_provider.rb
@@ -32,6 +32,7 @@ module Publisher
       # @option args [String] :summary_type
       # @option args [Symbol] :summary_table_type
       # @option args [Boolean] :collapse_summay
+      # @option args [Boolean] :flaky_warning_status
       # @option args [Boolean] :unresolved_discussion_on_failure
       # @option args [String] :report_title
       def initialize(**args)
@@ -41,6 +42,7 @@ module Publisher
         @summary_type = args[:summary_type]
         @summary_table_type = args[:summary_table_type]
         @collapse_summary = args[:collapse_summary]
+        @flaky_warning_status = args[:flaky_warning_status]
         @unresolved_discussion_on_failure = args[:unresolved_discussion_on_failure]
         @report_title = args[:report_title]
       end
@@ -62,6 +64,7 @@ module Publisher
                   :summary_type,
                   :collapse_summary,
                   :summary_table_type,
+                  :flaky_warning_status,
                   :unresolved_discussion_on_failure,
                   :report_title
 
@@ -106,6 +109,7 @@ module Publisher
           summary_type: summary_type,
           summary_table_type: summary_table_type,
           collapse_summary: collapse_summary,
+          flaky_warning_status: flaky_warning_status,
           report_title: report_title
         )
       end

--- a/spec/allure_report_publisher/commands/common_uploader_command.rb
+++ b/spec/allure_report_publisher/commands/common_uploader_command.rb
@@ -49,6 +49,7 @@ RSpec.shared_examples "upload command" do
       summary_table_type: :ascii,
       collapse_summary: false,
       unresolved_discussion_on_failure: false,
+      flaky_warning_status: false,
       report_title: report_title
     }
   end

--- a/spec/allure_report_publisher/helpers/summary_spec.rb
+++ b/spec/allure_report_publisher/helpers/summary_spec.rb
@@ -1,5 +1,12 @@
 RSpec.shared_examples "summary fetcher" do |summary_table_style|
-  subject(:summary) { described_class.new(report_path, summary_type, summary_table_style) }
+  subject(:summary) do
+    described_class.new(
+      report_path,
+      summary_type,
+      summary_table_style,
+      flaky_warning_status: flaky_warning_status
+    )
+  end
 
   let(:report_path) { "spec/fixture/fake_report" }
   let(:markdown) { summary_table_style == :markdown }
@@ -22,6 +29,8 @@ RSpec.shared_examples "summary fetcher" do |summary_table_style|
 end
 
 RSpec.describe Publisher::Helpers::Summary, epic: "helpers" do
+  let(:flaky_warning_status) { true }
+
   context "with expanded summary" do
     context "with behavior summary" do
       let(:summary_type) { Publisher::Helpers::Summary::BEHAVIORS }
@@ -91,5 +100,22 @@ RSpec.describe Publisher::Helpers::Summary, epic: "helpers" do
       it_behaves_like "summary fetcher", :ascii
       it_behaves_like "summary fetcher", :markdown
     end
+  end
+
+  context "with flaky warning status disabled" do
+    let(:flaky_warning_status) { false }
+    let(:summary_type) { Publisher::Helpers::Summary::PACKAGES }
+    let(:status) { "✅" }
+
+    let(:rows) do
+      lambda do |table|
+        [["epic name", 4, 0, 1, 0, 5, "✅"], ["epic name 2", 1, 0, 0, 1, 1, "✅"]].each { |row| table << row }
+        table << :separator
+        table << ["Total", 5, 0, 1, 1, 6, "✅"]
+      end
+    end
+
+    it_behaves_like "summary fetcher", :ascii
+    it_behaves_like "summary fetcher", :markdown
   end
 end

--- a/spec/allure_report_publisher/lib/providers/common_provider.rb
+++ b/spec/allure_report_publisher/lib/providers/common_provider.rb
@@ -7,6 +7,7 @@ RSpec.shared_context "with provider helper" do
       summary_type: summary_type,
       summary_table_type: summary_table_type,
       collapse_summary: collapse_summary,
+      flaky_warning_status: false,
       unresolved_discussion_on_failure: unresolved_discussion_on_failure,
       report_title: report_title
     )
@@ -42,6 +43,7 @@ RSpec.shared_context "with provider helper" do
         summary_type: summary_type,
         summary_table_type: summary_table_type,
         collapse_summary: collapse_summary,
+        flaky_warning_status: false,
         report_title: report_title
       )
       .and_return(url_builder)


### PR DESCRIPTION
Make behavior to mark test status with ❗configurable via `--flaky-warning-status` argument and set it to `false` by default.

<!-- allure -->
---
# Allure Report
`allure-report-publisher` generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/604/merge/7140282399/index.html) for [31ba254d](https://github.com/andrcuns/allure-report-publisher/pull/604/commits/31ba254d4bbacf2902596aebe2213b95a1e604c9)
```markdown
+------------------------------------------------------------------------------------------------------+
|                                          behaviors summary                                           |
+-------------------------------------------------+--------+--------+---------+-------+-------+--------+
|                                                 | passed | failed | skipped | flaky | total | result |
+-------------------------------------------------+--------+--------+---------+-------+-------+--------+
| commands                                        | 93     | 0      | 0       | 0     | 93    | ✅     |
| helpers                                         | 129    | 0      | 0       | 0     | 129   | ✅     |
| providers                                       | 54     | 0      | 0       | 0     | 54    | ✅     |
| uploaders                                       | 51     | 0      | 0       | 0     | 51    | ✅     |
| spec/allure_report_publisher/lib/providers/info | 15     | 0      | 0       | 0     | 15    | ✅     |
| generator                                       | 6      | 0      | 0       | 0     | 6     | ✅     |
| cli                                             | 3      | 0      | 0       | 0     | 3     | ✅     |
+-------------------------------------------------+--------+--------+---------+-------+-------+--------+
| Total                                           | 351    | 0      | 0       | 0     | 351   | ✅     |
+-------------------------------------------------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->