### PR TITLE
Log full backtrace to debug log

### DIFF
--- a/lib/allure_report_publisher/lib/helpers/spinner.rb
+++ b/lib/allure_report_publisher/lib/helpers/spinner.rb
@@ -121,7 +121,9 @@ module Publisher
     # @return [void]
     def spinner_error(error)
       message = ["failed", error.message]
-      message << error.backtrace if debug
+      log_debug("Error: #{error.message}")
+      log_debug(error.backtrace.join("\n"))
+
       colored_message = colorize(message.compact.join("\n"), error_color)
       return spinner.error(colored_message) if tty?
 

--- a/lib/allure_report_publisher/lib/helpers/spinner.rb
+++ b/lib/allure_report_publisher/lib/helpers/spinner.rb
@@ -121,8 +121,7 @@ module Publisher
     # @return [void]
     def spinner_error(error)
       message = ["failed", error.message]
-      log_debug("Error: #{error.message}")
-      log_debug(error.backtrace.join("\n"))
+      log_debug("Error: #{error.message}\n#{error.backtrace.join("\n")}")
 
       colored_message = colorize(message.compact.join("\n"), error_color)
       return spinner.error(colored_message) if tty?


### PR DESCRIPTION
Add more consistent `debug` behavior and log full error stracktraces to debug log output

<!-- allure -->
---
# Test Report
[`allure-report-publisher`](https://github.com/andrcuns/allure-report-publisher) generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/607/merge/7140989578/index.html) for [021bfaab](https://github.com/andrcuns/allure-report-publisher/pull/607/commits/021bfaab42aa254c2813204ab8611d97f24fddbc)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| providers | 69     | 0      | 0       | 0     | 69    | ✅     |
| helpers   | 129    | 0      | 0       | 0     | 129   | ✅     |
| commands  | 93     | 0      | 0       | 0     | 93    | ✅     |
| uploaders | 51     | 0      | 0       | 0     | 51    | ✅     |
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 351    | 0      | 0       | 0     | 351   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->