### PR TITLE
Correctly cast summary-table-type argument when provided via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Options:
   --update-pr=VALUE                 # Add report url to PR via comment or description update. Required: false: (comment/description/actions)
   --report-title=VALUE              # Title for url section in PR comment/description. Required: false, default: "Allure Report"
   --summary=VALUE                   # Additionally add summary table to PR comment or description. Required: false: (behaviors/suites/packages/total), default: "total"
-  --summary-table-type=VALUE        # Summary table type. Required: false: (ascii/markdown), default: :ascii
+  --summary-table-type=VALUE        # Summary table type. Required: false: (ascii/markdown), default: "ascii"
   --base-url=VALUE                  # Use custom base url instead of default cloud provider one. Required: false
   --[no-]flaky-warning-status       # Mark run with a '!' status in PR comment/description if report contains flaky tests, default: false
   --[no-]collapse-summary           # Create summary as a collapsible section, default: false

--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -42,10 +42,10 @@ module Publisher
       option :summary_table_type,
              type: :string,
              desc: "Summary table type. Required: false",
-             default: Publisher::Helpers::Summary::ASCII,
+             default: Publisher::Helpers::Summary::ASCII.to_s,
              values: [
-               Publisher::Helpers::Summary::ASCII,
-               Publisher::Helpers::Summary::MARKDOWN
+               Publisher::Helpers::Summary::ASCII.to_s,
+               Publisher::Helpers::Summary::MARKDOWN.to_s
              ]
       option :base_url,
              type: :string,
@@ -121,10 +121,10 @@ module Publisher
           report_url: uploader.report_url,
           report_path: uploader.report_path,
           summary_type: args[:summary],
+          summary_table_type: args[:summary_table_type].to_sym,
           **args.slice(
             :update_pr,
             :collapse_summary,
-            :summary_table_type,
             :flaky_warning_status,
             :unresolved_discussion_on_failure,
             :report_title

--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -42,10 +42,10 @@ module Publisher
       option :summary_table_type,
              type: :string,
              desc: "Summary table type. Required: false",
-             default: Publisher::Helpers::Summary::ASCII.to_s,
+             default: Publisher::Helpers::Summary::ASCII,
              values: [
-               Publisher::Helpers::Summary::ASCII.to_s,
-               Publisher::Helpers::Summary::MARKDOWN.to_s
+               Publisher::Helpers::Summary::ASCII,
+               Publisher::Helpers::Summary::MARKDOWN
              ]
       option :base_url,
              type: :string,
@@ -121,11 +121,11 @@ module Publisher
           report_url: uploader.report_url,
           report_path: uploader.report_path,
           summary_type: args[:summary],
-          summary_table_type: args[:summary_table_type].to_sym,
           **args.slice(
             :update_pr,
             :collapse_summary,
             :flaky_warning_status,
+            :summary_table_type,
             :unresolved_discussion_on_failure,
             :report_title
           )

--- a/lib/allure_report_publisher/lib/helpers/summary.rb
+++ b/lib/allure_report_publisher/lib/helpers/summary.rb
@@ -9,8 +9,8 @@ module Publisher
       PACKAGES = "packages".freeze
       SUITES = "suites".freeze
       TOTAL = "total".freeze
-      MARKDOWN = :markdown
-      ASCII = :ascii
+      MARKDOWN = "markdown".freeze
+      ASCII = "ascii".freeze
 
       # Summary table generator
       #
@@ -115,7 +115,7 @@ module Publisher
       def terminal_table
         Terminal::Table.new do |table|
           table.title = "#{summary_type} summary" unless markdown?
-          table.style = { border: table_type }
+          table.style = { border: table_type.to_sym }
           table.headings = ["", "passed", "failed", "skipped", "flaky", "total", "result"]
           yield(table)
         end

--- a/spec/allure_report_publisher/commands/common_uploader_command.rb
+++ b/spec/allure_report_publisher/commands/common_uploader_command.rb
@@ -46,7 +46,7 @@ RSpec.shared_examples "upload command" do
       report_url: report_url,
       report_path: report_path,
       summary_type: Publisher::Helpers::Summary::TOTAL,
-      summary_table_type: :ascii,
+      summary_table_type: Publisher::Helpers::Summary::ASCII,
       collapse_summary: false,
       unresolved_discussion_on_failure: false,
       flaky_warning_status: false,
@@ -99,7 +99,11 @@ RSpec.shared_examples "upload command" do
                     { update_pr: "comment", summary_type: "behaviors" }
     it_behaves_like "command", ["--update-pr=comment", "--summary=behaviors", "--summary-table-type=markdown"],
                     {},
-                    { update_pr: "comment", summary_type: "behaviors", summary_table_type: :markdown }
+                    {
+                      update_pr: "comment",
+                      summary_type: "behaviors",
+                      summary_table_type: Publisher::Helpers::Summary::MARKDOWN
+                    }
     it_behaves_like "command", ["--base-url=https://my-url.com"],
                     { base_url: "https://my-url.com" },
                     {}

--- a/spec/allure_report_publisher/helpers/summary_spec.rb
+++ b/spec/allure_report_publisher/helpers/summary_spec.rb
@@ -9,17 +9,18 @@ RSpec.shared_examples "summary fetcher" do |summary_table_style|
   end
 
   let(:report_path) { "spec/fixture/fake_report" }
-  let(:markdown) { summary_table_style == :markdown }
+  let(:markdown) { summary_table_style == Publisher::Helpers::Summary::MARKDOWN }
 
   let(:summary_table) do
     terminal_table = Terminal::Table.new do |table|
       table.title = "#{summary_type || 'total'} summary" unless markdown
-      table.style = { border: summary_table_style }
+      table.style = { border: summary_table_style.to_sym }
       table.headings = ["", "passed", "failed", "skipped", "flaky", "total", "result"]
       rows.call(table)
     end
+    next terminal_table.to_s if markdown
 
-    summary_table_style == :ascii ? "```markdown\n#{terminal_table}\n```" : terminal_table.to_s
+    "```markdown\n#{terminal_table}\n```"
   end
 
   it "fetches #{summary_table_style} summary table", :aggregate_failures do
@@ -45,8 +46,8 @@ RSpec.describe Publisher::Helpers::Summary, epic: "helpers" do
         end
       end
 
-      it_behaves_like "summary fetcher", :ascii
-      it_behaves_like "summary fetcher", :markdown
+      it_behaves_like "summary fetcher", Publisher::Helpers::Summary::ASCII
+      it_behaves_like "summary fetcher", Publisher::Helpers::Summary::MARKDOWN
     end
 
     context "with packages summary" do
@@ -61,8 +62,8 @@ RSpec.describe Publisher::Helpers::Summary, epic: "helpers" do
         end
       end
 
-      it_behaves_like "summary fetcher", :ascii
-      it_behaves_like "summary fetcher", :markdown
+      it_behaves_like "summary fetcher", Publisher::Helpers::Summary::ASCII
+      it_behaves_like "summary fetcher", Publisher::Helpers::Summary::MARKDOWN
     end
 
     context "with suites summary" do
@@ -77,8 +78,8 @@ RSpec.describe Publisher::Helpers::Summary, epic: "helpers" do
         end
       end
 
-      it_behaves_like "summary fetcher", :ascii
-      it_behaves_like "summary fetcher", :markdown
+      it_behaves_like "summary fetcher", Publisher::Helpers::Summary::ASCII
+      it_behaves_like "summary fetcher", Publisher::Helpers::Summary::MARKDOWN
     end
   end
 
@@ -91,15 +92,15 @@ RSpec.describe Publisher::Helpers::Summary, epic: "helpers" do
     end
 
     context "with explicitly provided provided type" do
-      it_behaves_like "summary fetcher", :ascii
-      it_behaves_like "summary fetcher", :markdown
+      it_behaves_like "summary fetcher", Publisher::Helpers::Summary::ASCII
+      it_behaves_like "summary fetcher", Publisher::Helpers::Summary::MARKDOWN
     end
 
     context "without explicitly provided provided type" do
       let(:summary_type) { nil }
 
-      it_behaves_like "summary fetcher", :ascii
-      it_behaves_like "summary fetcher", :markdown
+      it_behaves_like "summary fetcher", Publisher::Helpers::Summary::ASCII
+      it_behaves_like "summary fetcher", Publisher::Helpers::Summary::MARKDOWN
     end
   end
 
@@ -116,7 +117,7 @@ RSpec.describe Publisher::Helpers::Summary, epic: "helpers" do
       end
     end
 
-    it_behaves_like "summary fetcher", :ascii
-    it_behaves_like "summary fetcher", :markdown
+    it_behaves_like "summary fetcher", Publisher::Helpers::Summary::ASCII
+    it_behaves_like "summary fetcher", Publisher::Helpers::Summary::MARKDOWN
   end
 end


### PR DESCRIPTION
<!-- allure -->
# Test Report
[`allure-report-publisher`](https://github.com/andrcuns/allure-report-publisher) generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/608/merge/7141315038/index.html) for [39f142df](https://github.com/andrcuns/allure-report-publisher/pull/608/commits/39f142df219a3039c8d745b4adfd423fcf17ffbf)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| commands  | 93     | 0      | 0       | 0     | 93    | ✅     |
| helpers   | 129    | 0      | 0       | 0     | 129   | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| providers | 69     | 0      | 0       | 0     | 69    | ✅     |
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
| uploaders | 51     | 0      | 0       | 0     | 51    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 351    | 0      | 0       | 0     | 351   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->