### PR TITLE
Fix mr pipeline detection for child pipelines

### DIFF
--- a/lib/allure_report_publisher/lib/providers/gitlab.rb
+++ b/lib/allure_report_publisher/lib/providers/gitlab.rb
@@ -12,6 +12,7 @@ module Publisher
 
       def_delegators :"Publisher::Providers::Info::Gitlab.instance",
                      :allure_project,
+                     :mr_iid,
                      :allure_mr_iid,
                      :server_url,
                      :build_name
@@ -66,13 +67,6 @@ module Publisher
       # @return [String]
       def project
         @project ||= allure_project || env("CI_MERGE_REQUEST_PROJECT_PATH") || env("CI_PROJECT_PATH")
-      end
-
-      # Merge request iid
-      #
-      # @return [Integer]
-      def mr_iid
-        @mr_iid ||= allure_mr_iid || env("CI_MERGE_REQUEST_IID")
       end
 
       # Commit sha url

--- a/lib/allure_report_publisher/lib/providers/info/gitlab.rb
+++ b/lib/allure_report_publisher/lib/providers/info/gitlab.rb
@@ -27,7 +27,7 @@ module Publisher
         #
         # @return [Boolean]
         def pr?
-          !!(allure_project && allure_mr_iid) || ENV["CI_PIPELINE_SOURCE"] == "merge_request_event"
+          !!((allure_project && allure_mr_iid) || mr_iid)
         end
 
         # Get ci run ID without creating instance of ci provider
@@ -56,6 +56,13 @@ module Publisher
         # @return [String]
         def allure_project
           @allure_project ||= env("ALLURE_PROJECT_PATH")
+        end
+
+        # Merge request iid
+        #
+        # @return [Integer]
+        def mr_iid
+          @mr_iid ||= allure_mr_iid || env("CI_MERGE_REQUEST_IID")
         end
 
         # Custom mr iid name

--- a/spec/allure_report_publisher/lib/providers/info/gitlab_spec.rb
+++ b/spec/allure_report_publisher/lib/providers/info/gitlab_spec.rb
@@ -1,15 +1,15 @@
 RSpec.describe Publisher::Providers::Info::Gitlab, epic: "providers" do
   subject(:pr) { described_class.instance.pr? }
 
+  let(:mr_iid) { nil }
   let(:allure_project) { nil }
   let(:allure_mr_iid) { nil }
-  let(:pipeline_source) { "push" }
 
   let(:env) do
     {
       ALLURE_PROJECT_PATH: allure_project,
       ALLURE_MERGE_REQUEST_IID: allure_mr_iid,
-      CI_PIPELINE_SOURCE: pipeline_source
+      CI_MERGE_REQUEST_IID: mr_iid
     }
   end
 
@@ -18,12 +18,12 @@ RSpec.describe Publisher::Providers::Info::Gitlab, epic: "providers" do
   end
 
   describe "#pr?" do
-    context "with push event" do
+    context "with non merge request pipeline" do
       it { is_expected.to be(false) }
     end
 
-    context "with merge request event" do
-      let(:pipeline_source) { "merge_request_event" }
+    context "with merge request pipeline" do
+      let(:mr_iid) { "1" }
 
       it { is_expected.to be(true) }
     end


### PR DESCRIPTION
When pipeline on Gitlab CI is a child pipeline, `pipeline_source` will not be `merge_request_pipeline`. Switch to checking for `mr_iid` as a more reliable way of detecting mr context

<!-- allure -->
---
# Test Report
[`allure-report-publisher`](https://github.com/andrcuns/allure-report-publisher) generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/610/merge/7166670205/index.html) for [04192682](https://github.com/andrcuns/allure-report-publisher/pull/610/commits/0419268274e747d041c5aed7c3495ae55b058c02)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| helpers   | 129    | 0      | 0       | 0     | 129   | ✅     |
| commands  | 93     | 0      | 0       | 0     | 93    | ✅     |
| uploaders | 51     | 0      | 0       | 0     | 51    | ✅     |
| providers | 69     | 0      | 0       | 0     | 69    | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
| generator | 6      | 0      | 0       | 0     | 6     | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 351    | 0      | 0       | 0     | 351   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->