### PR TITLE
Adds an option to use custom ALLURE_RUN_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Authentication for PR updates:
 Following environment variables can override default CI values:
 
 - `ALLURE_JOB_NAME`: overrides default `GITHUB_JOB` value which is used as name for report url section
+- `ALLURE_RUN_ID`: overrides default `GITHUB_RUN_ID` value which is used as name for the run number
 
 ### allure-publish-action
 
@@ -176,6 +177,7 @@ Authentication for MR updates:
 Following environment variables can override default CI values:
 
 - `ALLURE_JOB_NAME`: overrides default `CI_JOB_NAME` value which is used as name for report url section
+- `ALLURE_RUN_ID`: overrides default `CI_PIPELINE_ID` value which is used as name for the run number
 
 In case merge request triggers a downstream pipeline yet you want to update original merge request, overriding following environment variables might be useful:
 

--- a/lib/allure_report_publisher/lib/providers/info/_base.rb
+++ b/lib/allure_report_publisher/lib/providers/info/_base.rb
@@ -7,6 +7,7 @@ module Publisher
       #
       class Base
         ALLURE_JOB_NAME = "ALLURE_JOB_NAME".freeze
+        ALLURE_RUN_ID = "ALLURE_RUN_ID".freeze
 
         # :nocov:
 

--- a/lib/allure_report_publisher/lib/providers/info/github.rb
+++ b/lib/allure_report_publisher/lib/providers/info/github.rb
@@ -34,7 +34,7 @@ module Publisher
         #
         # @return [String]
         def run_id
-          @run_id ||= env("GITHUB_RUN_ID")
+          @run_id ||= env(ALLURE_RUN_ID) || env("GITHUB_RUN_ID")
         end
 
         # Server url

--- a/lib/allure_report_publisher/lib/providers/info/gitlab.rb
+++ b/lib/allure_report_publisher/lib/providers/info/gitlab.rb
@@ -34,7 +34,7 @@ module Publisher
         #
         # @return [String]
         def run_id
-          @run_id ||= ENV["CI_PIPELINE_ID"]
+          @run_id ||= env(ALLURE_RUN_ID) || ENV["CI_PIPELINE_ID"]
         end
 
         # Server url


### PR DESCRIPTION
With this PR I aim to introduce support for a new environment variable called `ALLURE_RUN_ID` which works in a similar way like `ALLURE_JOB_NAME`.

The usecase why I'd like to introduce this change, is to allow myself to use `GITHUB_RUN_NUMBER` (e.g. `3` instead of `GITHUB_RUN_ID` (e.g. `1658821493`), without breaking it for others. Run number is easier to remember and use e.g. during daily reviews of nightly regression test runs.