### PR TITLE
Add ability to set custom report name in final allure report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,7 @@ jobs:
               --summary="behaviors" \
               --summary-table-type="${{ matrix.table }}" \
               --report-title="Test Report" \
+              --report-name="Test Report" \
               --copy-latest \
               --color \
               --debug

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Options:
   --summary=VALUE                   # Additionally add summary table to PR comment or description. Required: false: (behaviors/suites/packages/total), default: "total"
   --summary-table-type=VALUE        # Summary table type. Required: false: (ascii/markdown), default: "ascii"
   --base-url=VALUE                  # Use custom base url instead of default cloud provider one. Required: false
+  --report-name=VALUE               # Custom report name. Required: false
   --[no-]flaky-warning-status       # Mark run with a '!' status in PR comment/description if report contains flaky tests, default: false
   --[no-]collapse-summary           # Create summary as a collapsible section, default: false
   --[no-]copy-latest                # Keep copy of latest report at base prefix path, default: false

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Options:
   --prefix=VALUE                    # Optional prefix for report path. Required: false
   --update-pr=VALUE                 # Add report url to PR via comment or description update. Required: false: (comment/description/actions)
   --report-title=VALUE              # Title for url section in PR comment/description. Required: false, default: "Allure Report"
+  --report-name=VALUE               # Custom report name in final Allure report. Required: false
   --summary=VALUE                   # Additionally add summary table to PR comment or description. Required: false: (behaviors/suites/packages/total), default: "total"
   --summary-table-type=VALUE        # Summary table type. Required: false: (ascii/markdown), default: "ascii"
   --base-url=VALUE                  # Use custom base url instead of default cloud provider one. Required: false
-  --report-name=VALUE               # Custom report name. Required: false
   --[no-]flaky-warning-status       # Mark run with a '!' status in PR comment/description if report contains flaky tests, default: false
   --[no-]collapse-summary           # Create summary as a collapsible section, default: false
   --[no-]copy-latest                # Keep copy of latest report at base prefix path, default: false

--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -29,6 +29,9 @@ module Publisher
              type: :string,
              default: "Allure Report",
              desc: "Title for url section in PR comment/description. Required: false"
+      option :report_name,
+             type: :string,
+             desc: "Custom report name in final Allure report. Required: false"
       option :summary,
              type: :string,
              desc: "Additionally add summary table to PR comment or description. Required: false",
@@ -50,9 +53,6 @@ module Publisher
       option :base_url,
              type: :string,
              desc: "Use custom base url instead of default cloud provider one. Required: false"
-      option :report_name,
-             type: :string,
-             desc: "Custom report name. Required: false"
       option :flaky_warning_status,
              type: :boolean,
              default: false,

--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -50,6 +50,9 @@ module Publisher
       option :base_url,
              type: :string,
              desc: "Use custom base url instead of default cloud provider one. Required: false"
+      option :report_name,
+             type: :string,
+             desc: "Custom report name. Required: false"
       option :flaky_warning_status,
              type: :boolean,
              default: false,
@@ -109,7 +112,7 @@ module Publisher
       def uploader
         @uploader ||= uploaders(args[:type]).new(
           result_paths: @result_paths,
-          **args.slice(:bucket, :prefix, :base_url, :copy_latest)
+          **args.slice(:bucket, :prefix, :base_url, :copy_latest, :report_name)
         )
       end
 

--- a/lib/allure_report_publisher/lib/report_generator.rb
+++ b/lib/allure_report_publisher/lib/report_generator.rb
@@ -10,8 +10,9 @@ module Publisher
   class ReportGenerator
     include Helpers
 
-    def initialize(result_paths)
+    def initialize(result_paths, report_name)
       @result_paths = result_paths.join(" ")
+      @report_name = report_name
     end
 
     # Generate allure report
@@ -44,14 +45,18 @@ module Publisher
 
     # @return [String] result paths string
     attr_reader :result_paths
+    # @return [String] custom report name
+    attr_reader :report_name
 
     # Generate allure report
     #
     # @return [void]
     def generate_report
       log_debug("Generating allure report")
-      cmd = "allure generate --clean --output #{report_path} #{common_info_path} #{result_paths}"
-      out = execute_shell(cmd)
+      cmd = ["allure generate --clean"]
+      cmd << "--report-name #{report_name}" if report_name
+      cmd << "--output #{report_path} #{common_info_path} #{result_paths}"
+      out = execute_shell(cmd.join(" "))
       log_debug("Generated allure report. #{out}".strip)
 
       deduplicate_executors

--- a/lib/allure_report_publisher/lib/report_generator.rb
+++ b/lib/allure_report_publisher/lib/report_generator.rb
@@ -54,7 +54,7 @@ module Publisher
     def generate_report
       log_debug("Generating allure report")
       cmd = ["allure generate --clean"]
-      cmd << "--report-name #{report_name}" if report_name
+      cmd << "--report-name '#{report_name}'" if report_name
       cmd << "--output #{report_path} #{common_info_path} #{result_paths}"
       out = execute_shell(cmd.join(" "))
       log_debug("Generated allure report. #{out}".strip)

--- a/lib/allure_report_publisher/lib/uploaders/_uploader.rb
+++ b/lib/allure_report_publisher/lib/uploaders/_uploader.rb
@@ -30,12 +30,14 @@ module Publisher
       # @option args [String] :prefix
       # @option args [String] :base_url
       # @option args [String] :copy_latest
+      # @option args [String] :report_name
       def initialize(**args)
         @result_paths = args[:result_paths]
         @bucket_name = args[:bucket]
         @prefix = args[:prefix]
         @base_url = args[:base_url]
         @copy_latest = ci_info && args[:copy_latest] # copy latest for ci only
+        @report_name = args[:report_name]
       end
 
       # Execute allure report generation and upload
@@ -94,7 +96,8 @@ module Publisher
                   :bucket_name,
                   :prefix,
                   :base_url,
-                  :copy_latest
+                  :copy_latest,
+                  :report_name
 
       def_delegator :report_generator, :common_info_path
 
@@ -155,7 +158,7 @@ module Publisher
       #
       # @return [Publisher::ReportGenerator]
       def report_generator
-        @report_generator ||= ReportGenerator.new(result_paths)
+        @report_generator ||= ReportGenerator.new(result_paths, report_name)
       end
 
       # Report path prefix

--- a/spec/allure_report_publisher/lib/report_generator_spec.rb
+++ b/spec/allure_report_publisher/lib/report_generator_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Publisher::ReportGenerator, epic: "generator" do
           report_generator.generate
 
           expect(Open3).to have_received(:capture3).with(
-            "allure generate --clean --report-name #{report_name} " \
+            "allure generate --clean --report-name '#{report_name}' " \
             "--output #{report_dir} #{common_info_dir} #{result_paths.join(' ')}"
           )
           expect(File).to have_received(:write).with("#{report_dir}/widgets/executors.json", deduped_executors)

--- a/spec/allure_report_publisher/lib/uploaders/common_uploader.rb
+++ b/spec/allure_report_publisher/lib/uploaders/common_uploader.rb
@@ -16,6 +16,7 @@ RSpec.shared_context "with uploader" do
   let(:base_url) { nil }
   let(:ci_provider) { nil }
   let(:run_id) { "123" }
+  let(:report_name) { nil }
 
   let(:history_files) do
     [
@@ -33,7 +34,8 @@ RSpec.shared_context "with uploader" do
       bucket: bucket_name,
       prefix: prefix,
       base_url: base_url,
-      copy_latest: false
+      copy_latest: false,
+      report_name: report_name
     }
   end
 

--- a/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
       described_class.new(**args).execute
 
       aggregate_failures do
-        expect(Publisher::ReportGenerator).to have_received(:new).with(result_paths)
+        expect(Publisher::ReportGenerator).to have_received(:new).with(result_paths, report_name)
         expect(report_generator).to have_received(:generate)
       end
     end


### PR DESCRIPTION
See: https://github.com/allure-framework/allure2/pull/2229

<!-- allure -->
---
# Test Report
[`allure-report-publisher`](https://github.com/andrcuns/allure-report-publisher) generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/633/merge/7646356892/index.html) for [999c4330](https://github.com/andrcuns/allure-report-publisher/pull/633/commits/999c433062b27076221d170d705f848ea80e5630)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| providers | 92     | 0      | 0       | 0     | 92    | ✅     |
| commands  | 124    | 0      | 0       | 0     | 124   | ✅     |
| generator | 12     | 0      | 0       | 0     | 12    | ✅     |
| uploaders | 72     | 0      | 0       | 0     | 72    | ✅     |
| helpers   | 172    | 0      | 0       | 0     | 172   | ✅     |
| cli       | 4      | 0      | 0       | 0     | 4     | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 476    | 0      | 0       | 0     | 476   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->