### PR TITLE
Do not load all files in memory when uploading to s3

### DIFF
--- a/spec/allure_report_publisher/lib/uploaders/s3_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/s3_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Publisher::Uploaders::S3, epic: "uploaders" do
   let(:history_latest) { history_run.merge(key: "#{prefix}/history/history.json") }
   let(:history_run) do
     {
-      body: File.new("spec/fixture/fake_report/history/history.json"),
+      body: File.read("spec/fixture/fake_report/history/history.json"),
       bucket: bucket_name,
       key: "#{prefix}/#{run_id}/history/history.json",
       content_type: "application/json",
@@ -37,7 +37,7 @@ RSpec.describe Publisher::Uploaders::S3, epic: "uploaders" do
   let(:report_latest) { report_run.merge(key: "#{prefix}/index.html") }
   let(:report_run) do
     {
-      body: File.new("spec/fixture/fake_report/index.html"),
+      body: File.read("spec/fixture/fake_report/index.html"),
       bucket: bucket_name,
       key: "#{prefix}/#{run_id}/index.html",
       content_type: "text/html",
@@ -47,9 +47,6 @@ RSpec.describe Publisher::Uploaders::S3, epic: "uploaders" do
 
   before do
     allow(Aws::S3::Client).to receive(:new).with({ region: "us-east-1", force_path_style: false }) { s3_client }
-    allow(File).to receive(:new).and_call_original
-    allow(File).to receive(:new).with(Pathname.new(history_latest[:body].path)) { history_latest[:body] }
-    allow(File).to receive(:new).with(Pathname.new(report_latest[:body].path)) { report_latest[:body] }
   end
 
   shared_examples "report generator" do
@@ -133,8 +130,6 @@ RSpec.describe Publisher::Uploaders::S3, epic: "uploaders" do
                                                    .and_return(existing_files)
 
       allow(File).to receive(:write)
-      allow(File).to receive(:new).with(Pathname.new(history_run[:body].path)) { history_run[:body] }
-      allow(File).to receive(:new).with(Pathname.new(report_run[:body].path)) { report_run[:body] }
     end
 
     it "uploads allure report to s3" do


### PR DESCRIPTION
Do not load all files in memory when uploading report to s3

Closes https://github.com/andrcuns/allure-report-publisher/issues/651

<!-- allure -->
---
# Test Report
[`allure-report-publisher`](https://github.com/andrcuns/allure-report-publisher) generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-tests-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/661/merge/8194340169/index.html) for [fecbead1](https://github.com/andrcuns/allure-report-publisher/pull/661/commits/fecbead1343407995c7c712a3acff1e5a9b32024)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| providers | 92     | 0      | 0       | 0     | 92    | ✅     |
| cli       | 4      | 0      | 0       | 0     | 4     | ✅     |
| helpers   | 172    | 0      | 0       | 0     | 172   | ✅     |
| uploaders | 72     | 0      | 0       | 0     | 72    | ✅     |
| commands  | 132    | 0      | 0       | 0     | 132   | ✅     |
| generator | 12     | 0      | 0       | 0     | 12    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 484    | 0      | 0       | 0     | 484   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->