### PR TITLE
Correctly validate cloud platform type argument

### DIFF
--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -148,13 +148,14 @@ module Publisher
         {
           "s3" => Uploaders::S3,
           "gcs" => Uploaders::GCS
-        }[uploader]
+        }.fetch(uploader)
       end
 
       # Validate required args
       #
       # @return [void]
       def validate_args
+        error("Unsupported cloud storage type! Supported types are: s3, gcs") unless %w[s3 gcs].include?(args[:type])
         error("Missing argument --results-glob!") unless args[:results_glob]
         error("Missing argument --bucket!") unless args[:bucket]
         URI.parse(args[:base_url]) if args[:base_url]


### PR DESCRIPTION
Raise proper error when providing invalid uploader type

<!-- allure -->
---
# Test Report
[`allure-report-publisher`](https://github.com/andrcuns/allure-report-publisher) generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://allure-reports.s3.amazonaws.com/allure-report-publisher/refs/pull/735/merge/9427473704/index.html) for [2f2f8817](https://github.com/andrcuns/allure-report-publisher/pull/735/commits/2f2f8817deb51d45d67fc2c4c126f634c58cd808)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| generator | 12     | 0      | 0       | 0     | 12    | ✅     |
| providers | 92     | 0      | 0       | 0     | 92    | ✅     |
| cli       | 4      | 0      | 0       | 0     | 4     | ✅     |
| helpers   | 172    | 0      | 0       | 0     | 172   | ✅     |
| uploaders | 72     | 0      | 0       | 0     | 72    | ✅     |
| commands  | 132    | 0      | 0       | 0     | 132   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 484    | 0      | 0       | 0     | 484   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->