### PR TITLE
Use custom aws endpoint for report url

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,12 +75,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: reports/allure-results
-      - name: Restore minio store
+      - name: Cache minio store
         id: cache-primes-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache@v4
         with:
           path: minio
-          key: minio/${{ github.ref_name }}
+          key: minio/${{ github.ref_name }}/${{ github.run_id }}
+          restore-keys: minio/${{ github.ref_name }}
       - name: Set up Minio
         run: |
           mkdir -p minio/allure-reports
@@ -126,8 +127,3 @@ jobs:
               --copy-latest \
               --color \
               --debug
-      - name: Save minio store
-        uses: actions/cache/save@v4
-        with:
-          path: minio
-          key: minio/${{ github.ref_name }}

--- a/lib/allure_report_publisher/lib/uploaders/s3.rb
+++ b/lib/allure_report_publisher/lib/uploaders/s3.rb
@@ -32,7 +32,7 @@ module Publisher
         @client_args ||= {
           region: ENV["AWS_REGION"] || "us-east-1",
           force_path_style: ENV["AWS_FORCE_PATH_STYLE"] == "true",
-          endpoint: ENV["AWS_ENDPOINT"]
+          endpoint: aws_endpoint
         }.compact
       end
 
@@ -41,6 +41,13 @@ module Publisher
       # @return [String]
       def latest_report_url
         @latest_report_url ||= url(prefix)
+      end
+
+      # Custom aws endpoint
+      #
+      # @return [<String, nil>]
+      def aws_endpoint
+        @aws_endpoint ||= ENV["AWS_ENDPOINT"]
       end
 
       # Add allure history
@@ -143,7 +150,11 @@ module Publisher
       # @param [String] path_prefix
       # @return [String]
       def url(path_prefix)
-        [base_url || "http://#{bucket_name}.s3.amazonaws.com", path_prefix, "index.html"].compact.join("/")
+        [
+          base_url || aws_endpoint || "http://#{bucket_name}.s3.amazonaws.com",
+          path_prefix,
+          "index.html"
+        ].compact.join("/")
       end
 
       # Get file content type

--- a/lib/allure_report_publisher/lib/uploaders/s3.rb
+++ b/lib/allure_report_publisher/lib/uploaders/s3.rb
@@ -158,8 +158,6 @@ module Publisher
       # @return [String]
       def url(path_prefix)
         custom_base = if aws_endpoint
-                        nil
-                      else
                         path_style? ? "#{aws_endpoint}/#{bucket_name}" : aws_endpoint
                       end
 

--- a/spec/allure_report_publisher/lib/uploaders/s3_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/s3_spec.rb
@@ -199,5 +199,20 @@ RSpec.describe Publisher::Uploaders::S3, epic: "uploaders" do
         })
       end
     end
+
+    context "with custom aws endpoint" do
+      let(:custom_endpoint) { "http://custom-endpoint" }
+
+      around do |example|
+        ClimateControl.modify(AWS_ENDPOINT: custom_endpoint, AWS_FORCE_PATH_STYLE: "true") { example.run }
+      end
+
+      it "returns correct report urls" do
+        expect(described_class.new(**args, copy_latest: true).report_urls).to eq({
+          "Report url" => "#{custom_endpoint}/#{bucket_name}/project/#{run_id}/index.html",
+          "Latest report url" => "#{custom_endpoint}/#{bucket_name}/project/index.html"
+        })
+      end
+    end
   end
 end


### PR DESCRIPTION
If custom aws endpoint is set, use it for constructing report url

<!-- allure -->
---
# Test Report
[`allure-report-publisher`](https://github.com/andrcuns/allure-report-publisher) generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://minio:9000/allure-reports/allure-report-publisher/refs/pull/736/merge/9427657744/index.html) for [7847500a](https://github.com/andrcuns/allure-report-publisher/pull/736/commits/7847500a5f012dec718d2c40b24350b977c771e4)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| providers | 92     | 0      | 0       | 0     | 92    | ✅     |
| commands  | 132    | 0      | 0       | 0     | 132   | ✅     |
| cli       | 4      | 0      | 0       | 0     | 4     | ✅     |
| generator | 12     | 0      | 0       | 0     | 12    | ✅     |
| helpers   | 172    | 0      | 0       | 0     | 172   | ✅     |
| uploaders | 76     | 0      | 0       | 0     | 76    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 488    | 0      | 0       | 0     | 488   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->