### PR TITLE
Fix spec metadata warning

### DIFF
--- a/allure-report-publisher.gemspec
+++ b/allure-report-publisher.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 3.0")
 
   spec.metadata = {
-    "homepage_uri" => spec.homepage,
     "source_code_uri" => "https://github.com/andrcuns/allure-report-uploader",
     "changelog_uri" => "https://github.com/andrcuns/allure-report-uploader/releases",
     "documentation_uri" => "https://github.com/andrcuns/allure-report-uploader/blob/master/README.md",


### PR DESCRIPTION
<!-- allure -->
# Test Report
[`allure-report-publisher`](https://github.com/andrcuns/allure-report-publisher) generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://minio:9000/allure-reports/allure-report-publisher/refs/pull/737/merge/9427712006/index.html) for [3a9162ec](https://github.com/andrcuns/allure-report-publisher/pull/737/commits/3a9162ec9b90c56db109b80025be173c7f47cc92)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| providers | 92     | 0      | 0       | 0     | 92    | ✅     |
| generator | 12     | 0      | 0       | 0     | 12    | ✅     |
| uploaders | 76     | 0      | 0       | 0     | 76    | ✅     |
| commands  | 132    | 0      | 0       | 0     | 132   | ✅     |
| cli       | 4      | 0      | 0       | 0     | 4     | ✅     |
| helpers   | 172    | 0      | 0       | 0     | 172   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 488    | 0      | 0       | 0     | 488   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->

<!-- jobs -->
<!-- allurestop -->