### PR TITLE
Correctly handle manually modified PR description

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -4,3 +4,5 @@ require "bundler/setup"
 require "allure_report_publisher"
 
 require "debug"
+
+binding.break # rubocop:disable Lint/Debugger

--- a/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
+++ b/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
@@ -4,7 +4,7 @@ module Publisher
     #
     class UrlSectionBuilder
       DESCRIPTION_PATTERN = /<!-- allure -->[\s\S]+<!-- allurestop -->/
-      JOBS_PATTERN = /<!-- jobs -->\n([\s\S]+)\n<!-- jobs -->/
+      JOBS_PATTERN = /<!-- jobs -->(?<jobs>[\s\S]+)<!-- jobs -->/
 
       # Url section builder
       #
@@ -106,7 +106,7 @@ module Publisher
           entry << "<summary>expand test summary</summary>\n" if collapse_summary
           entry << summary.table if summary_type
           entry << "</details>" if collapse_summary
-          entry << "<!-- #{build_name} -->\n"
+          entry << "<!-- #{build_name} -->"
 
           entry.join("\n")
         end
@@ -116,7 +116,7 @@ module Publisher
       #
       # @return [RegExp]
       def job_entry_pattern
-        @job_entry_pattern ||= /<!-- #{build_name} -->\n([\s\S]+)\n<!-- #{build_name} -->\n/
+        @job_entry_pattern ||= /<!-- #{build_name} -->[\s\S]+<!-- #{build_name} -->/
       end
 
       # Allure report url section
@@ -137,10 +137,10 @@ module Publisher
       # @param [String] body
       # @return [String]
       def jobs_section(body)
-        jobs = body.match(JOBS_PATTERN)[1]
-        return jobs.gsub(job_entry_pattern, job_entry) if jobs.match?(job_entry_pattern)
+        jobs = body.match(JOBS_PATTERN)[:jobs]
+        return jobs.gsub(job_entry_pattern, job_entry).strip if jobs.match?(job_entry_pattern)
 
-        "#{jobs}\n#{job_entry}"
+        "#{jobs.strip}\n#{job_entry}"
       end
     end
   end

--- a/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
+++ b/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
@@ -134,10 +134,10 @@ module Publisher
 
       # Return updated jobs section
       #
-      # @param [String] urls
+      # @param [String] body
       # @return [String]
-      def jobs_section(urls_block)
-        jobs = urls_block.match(JOBS_PATTERN)[1]
+      def jobs_section(body)
+        jobs = body.match(JOBS_PATTERN)[1]
         return jobs.gsub(job_entry_pattern, job_entry) if jobs.match?(job_entry_pattern)
 
         "#{jobs}\n#{job_entry}"

--- a/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
+++ b/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
@@ -123,18 +123,13 @@ module Publisher
       #
       # @return [String]
       def url_section(job_entries: job_entry, separator: true)
-        reports = <<~BODY.strip
-          <!-- allure -->
-          ---
-          #{heading}
-
+        <<~BODY.strip
+          <!-- allure -->#{separator ? "\n---\n" : "\n"}#{heading}\n
           <!-- jobs -->
           #{job_entries}
           <!-- jobs -->
           <!-- allurestop -->
         BODY
-
-        separator ? reports : reports.gsub("---\n", "")
       end
 
       # Return updated jobs section

--- a/spec/allure_report_publisher/helpers/url_section_builder_spec.rb
+++ b/spec/allure_report_publisher/helpers/url_section_builder_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Publisher::Helpers::UrlSectionBuilder, epic: "helpers" do
       entry << "<summary>expand test summary</summary>\n" if collapse
       entry << "```markdown\n#{summary_table}\n```" if summary_type
       entry << "</details>" if collapse
-      entry << "<!-- #{name} -->\n"
+      entry << "<!-- #{name} -->"
 
       entry.join("\n")
     end


### PR DESCRIPTION
Correctly handle edited pr description/comment that can update how newline character is set

<!-- allure -->
---
# Test Report
[`allure-report-publisher`](https://github.com/andrcuns/allure-report-publisher) generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://minio:9000/allure-reports/allure-report-publisher/refs/pull/738/merge/9428412291/index.html) for [040067e5](https://github.com/andrcuns/allure-report-publisher/pull/738/commits/040067e506a7af06333a7fb2d2180a3416c76d21)
```markdown
+----------------------------------------------------------------+
|                       behaviors summary                        |
+-----------+--------+--------+---------+-------+-------+--------+
|           | passed | failed | skipped | flaky | total | result |
+-----------+--------+--------+---------+-------+-------+--------+
| commands  | 132    | 0      | 0       | 0     | 132   | ✅     |
| providers | 92     | 0      | 0       | 0     | 92    | ✅     |
| helpers   | 172    | 0      | 0       | 0     | 172   | ✅     |
| generator | 12     | 0      | 0       | 0     | 12    | ✅     |
| cli       | 4      | 0      | 0       | 0     | 4     | ✅     |
| uploaders | 76     | 0      | 0       | 0     | 76    | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
| Total     | 488    | 0      | 0       | 0     | 488   | ✅     |
+-----------+--------+--------+---------+-------+-------+--------+
```
<!-- rspec -->
<!-- jobs -->
<!-- allurestop -->