### PR TITLE
[BREAKING] Remove functionality for creating unresolved GitLab discussion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,9 +61,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - table: ascii
-            results: description
           - table: markdown
+            results: description
+          - table: ascii
             results: comment
           - table: markdown
             results: actions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: rspec
     if: always()
-    name: Publish Report
+    name: Publish report as ${{ matrix.results }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - table: ascii
+            results: description
+          - table: markdown
+            results: comment
+          - table: markdown
+            results: actions
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.6
@@ -119,9 +129,9 @@ jobs:
               --results-glob="/workspace/reports/allure-results/*" \
               --bucket="allure-reports" \
               --prefix="allure-report-publisher/$GITHUB_REF" \
-              --update-pr="description" \
+              --update-pr="${{ matrix.results }}" \
               --summary="behaviors" \
-              --summary-table-type="ascii" \
+              --summary-table-type="${{ matrix.table }}" \
               --report-title="Test Report" \
               --report-name="Test Report" \
               --copy-latest \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,7 @@ jobs:
         run: |
           docker run --rm \
             -v "$(pwd)":/workspace \
+            -v "$GITHUB_STEP_SUMMARY:$GITHUB_STEP_SUMMARY" \
             -v "$GITHUB_EVENT_PATH:$GITHUB_EVENT_PATH" \
             -e GITHUB_WORKFLOW="$GITHUB_WORKFLOW" \
             -e GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME" \
@@ -118,6 +119,7 @@ jobs:
             -e GITHUB_RUN_ID="$GITHUB_RUN_ID" \
             -e GITHUB_SHA="$GITHUB_SHA" \
             -e GITHUB_AUTH_TOKEN="$GITHUB_AUTH_TOKEN" \
+            -e GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" \
             -e AWS_ENDPOINT="http://minio:9000" \
             -e AWS_FORCE_PATH_STYLE="true" \
             -e AWS_ACCESS_KEY_ID="minioadmin" \

--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -76,10 +76,6 @@ module Publisher
              type: :boolean,
              default: false,
              desc: "Ignore missing allure results"
-      option :unresolved_discussion_on_failure,
-             type: :boolean,
-             default: false,
-             desc: "Add an unresolved discussion comment on test failure. GitLab only"
       option :debug,
              type: :boolean,
              default: false,
@@ -134,7 +130,6 @@ module Publisher
             :collapse_summary,
             :flaky_warning_status,
             :summary_table_type,
-            :unresolved_discussion_on_failure,
             :report_title
           )
         )

--- a/lib/allure_report_publisher/lib/providers/_provider.rb
+++ b/lib/allure_report_publisher/lib/providers/_provider.rb
@@ -33,7 +33,6 @@ module Publisher
       # @option args [Symbol] :summary_table_type
       # @option args [Boolean] :collapse_summay
       # @option args [Boolean] :flaky_warning_status
-      # @option args [Boolean] :unresolved_discussion_on_failure
       # @option args [String] :report_title
       def initialize(**args)
         @report_url = args[:report_url]
@@ -43,7 +42,6 @@ module Publisher
         @summary_table_type = args[:summary_table_type]
         @collapse_summary = args[:collapse_summary]
         @flaky_warning_status = args[:flaky_warning_status]
-        @unresolved_discussion_on_failure = args[:unresolved_discussion_on_failure]
         @report_title = args[:report_title]
       end
 
@@ -65,7 +63,6 @@ module Publisher
                   :collapse_summary,
                   :summary_table_type,
                   :flaky_warning_status,
-                  :unresolved_discussion_on_failure,
                   :report_title
 
       # Current pull request description

--- a/spec/allure_report_publisher/commands/common_uploader_command.rb
+++ b/spec/allure_report_publisher/commands/common_uploader_command.rb
@@ -49,7 +49,6 @@ RSpec.shared_examples "upload command" do
       summary_type: Publisher::Helpers::Summary::TOTAL,
       summary_table_type: Publisher::Helpers::Summary::ASCII,
       collapse_summary: false,
-      unresolved_discussion_on_failure: false,
       flaky_warning_status: false,
       report_title: report_title
     }


### PR DESCRIPTION
Remove functionality for creating unresolved discussions. This probably shouldn't have been added because:

* Reporter should stick to just displaying results without interfering with CI control flow
* Keep code simple and introduce as few provider specific options as possible

<!-- allure -->
---
# Test Report
[`allure-report-publisher`](https://github.com/andrcuns/allure-report-publisher) generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://minio:9000/allure-reports/allure-report-publisher/refs/pull/740/merge/9430393554/index.html) for [162d7019](https://github.com/andrcuns/allure-report-publisher/pull/740/commits/162d7019d637eda4b0599a8a3e4486fd8396bb51)
|           | passed | failed | skipped | flaky | total | result |
|-----------|--------|--------|---------|-------|-------|--------|
| providers | 76     | 0      | 0       | 0     | 76    | ✅     |
| helpers   | 172    | 0      | 0       | 0     | 172   | ✅     |
| commands  | 132    | 0      | 0       | 0     | 132   | ✅     |
| cli       | 4      | 0      | 0       | 0     | 4     | ✅     |
| uploaders | 76     | 0      | 0       | 0     | 76    | ✅     |
| generator | 12     | 0      | 0       | 0     | 12    | ✅     |
|-----------|--------|--------|---------|-------|-------|--------|
| Total     | 472    | 0      | 0       | 0     | 472   | ✅     |
<!-- rspec -->
<!-- jobs -->
<!-- allurestop -->