### PR TITLE
Add new line after each job in url section

### DIFF
--- a/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
+++ b/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
@@ -106,7 +106,7 @@ module Publisher
           entry << "<summary>expand test summary</summary>\n" if collapse_summary
           entry << summary.table if summary_type
           entry << "</details>" if collapse_summary
-          entry << "<!-- #{build_name} -->"
+          entry << "<!-- #{build_name} -->\n"
 
           entry.join("\n")
         end

--- a/spec/allure_report_publisher/helpers/url_section_builder_spec.rb
+++ b/spec/allure_report_publisher/helpers/url_section_builder_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Publisher::Helpers::UrlSectionBuilder, epic: "helpers" do
       entry << "<summary>expand test summary</summary>\n" if collapse
       entry << "```markdown\n#{summary_table}\n```" if summary_type
       entry << "</details>" if collapse
-      entry << "<!-- #{name} -->"
+      entry << "<!-- #{name} -->\n"
 
       entry.join("\n")
     end


### PR DESCRIPTION
I noticed that in https://gitlab.com/gitlab-org/gitlab/-/merge_requests/157874#note_1975686687 the headings are not bold. I think we may need the new line back. 🤔 