### PR TITLE
Fix regression for markdown not rendering job title in bold

### DIFF
--- a/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
+++ b/lib/allure_report_publisher/lib/helpers/url_section_builder.rb
@@ -140,7 +140,7 @@ module Publisher
         jobs = body.match(JOBS_PATTERN)[:jobs]
         return jobs.gsub(job_entry_pattern, job_entry).strip if jobs.match?(job_entry_pattern)
 
-        "#{jobs.strip}\n#{job_entry}"
+        "#{jobs.strip}\n\n#{job_entry}"
       end
     end
   end

--- a/spec/allure_report_publisher/helpers/url_section_builder_spec.rb
+++ b/spec/allure_report_publisher/helpers/url_section_builder_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Publisher::Helpers::UrlSectionBuilder, epic: "helpers" do
       entry.join("\n")
     end
 
-    markdowns.join("\n")
+    markdowns.join("\n\n")
   end
 
   def urls_section(job_section = jobs)


### PR DESCRIPTION
Adds missing new line for job names to render correctly

<!-- allure -->
---
# Test Report
[`allure-report-publisher`](https://github.com/andrcuns/allure-report-publisher) generated test report!

<!-- jobs -->
<!-- rspec -->
**rspec**: ✅ [test report](http://minio:9000/allure-reports/allure-report-publisher/refs/pull/767/merge/9771866138/index.html) for [41bc173b](https://github.com/andrcuns/allure-report-publisher/pull/767/commits/41bc173b23ace5a559291bff5a2060130931460c)
|           | passed | failed | skipped | flaky | total | result |
|-----------|--------|--------|---------|-------|-------|--------|
| providers | 57     | 0      | 0       | 0     | 57    | ✅     |
| helpers   | 129    | 0      | 0       | 0     | 129   | ✅     |
| uploaders | 57     | 0      | 0       | 0     | 57    | ✅     |
| generator | 9      | 0      | 0       | 0     | 9     | ✅     |
| commands  | 99     | 0      | 0       | 0     | 99    | ✅     |
| cli       | 3      | 0      | 0       | 0     | 3     | ✅     |
|-----------|--------|--------|---------|-------|-------|--------|
| Total     | 354    | 0      | 0       | 0     | 354   | ✅     |
<!-- rspec -->
<!-- jobs -->
<!-- allurestop -->