### PR TITLE
Add support for gitlab-artifacts storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/andrcuns/allure-report-publisher?color=blue&label=docker&sort=semver)](https://hub.docker.com/r/andrcuns/allure-report-publisher)
 [![Docker Pulls](https://img.shields.io/docker/pulls/andrcuns/allure-report-publisher)](https://hub.docker.com/r/andrcuns/allure-report-publisher)
 ![Workflow status](https://github.com/andrcuns/allure-report-publisher/workflows/Test/badge.svg)
-[![Maintainability](https://api.codeclimate.com/v1/badges/210eaa4f74588fb08313/maintainability)](https://codeclimate.com/github/andrcuns/allure-report-publisher/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/210eaa4f74588fb08313/test_coverage)](https://codeclimate.com/github/andrcuns/allure-report-publisher/test_coverage)
 
 Upload your report to a file storage of your choice.
 
@@ -38,22 +36,23 @@ Description:
   Generate and upload allure report
 
 Arguments:
-  TYPE                              # REQUIRED Cloud storage type: (s3/gcs)
+  TYPE                              # REQUIRED Cloud storage type: (gcs/s3/gitlab-artifacts)
 
 Options:
   --results-glob=VALUE              # Glob pattern to return allure results directories. Required: true
-  --bucket=VALUE                    # Bucket name. Required: true
-  --prefix=VALUE                    # Optional prefix for report path. Required: false
+  --bucket=VALUE                    # Bucket name. Required: true (gcs|s3), false (gitlab-artifacts)
+  --output=VALUE                    # Output directory for the report. Required: false. Defaults to 'allure-report' for gitlab-artifacts and random temporary directory for cloud based storage
+  --prefix=VALUE                    # Optional prefix for report path. Required: false. Ignored for gitlab-artifacts
   --update-pr=VALUE                 # Add report url to PR via comment or description update. Required: false: (comment/description/actions)
   --report-title=VALUE              # Title for url section in PR comment/description. Required: false, default: "Allure Report"
   --report-name=VALUE               # Custom report name in final Allure report. Required: false
   --summary=VALUE                   # Additionally add summary table to PR comment or description. Required: false: (behaviors/suites/packages/total), default: "total"
   --summary-table-type=VALUE        # Summary table type. Required: false: (ascii/markdown), default: "ascii"
-  --base-url=VALUE                  # Use custom base url instead of default cloud provider one. Required: false
+  --base-url=VALUE                  # Use custom base url instead of default cloud provider one. Required: false. Ignored for gitlab-artifacts
   --parallel=VALUE                  # Number of parallel threads to use for report file upload to cloud storage. Required: false, default: 8
   --[no-]flaky-warning-status       # Mark run with a '!' status in PR comment/description if report contains flaky tests, default: false
   --[no-]collapse-summary           # Create summary as a collapsible section, default: false
-  --[no-]copy-latest                # Keep copy of latest report at base prefix path, default: false
+  --[no-]copy-latest                # Keep copy of latest report at base prefix path. Ignored for gitlab-artifacts, default: false
   --[no-]color                      # Force color output
   --[no-]ignore-missing-results     # Ignore missing allure results, default: false
   --[no-]debug                      # Print additional debug output, default: false
@@ -62,6 +61,7 @@ Options:
 Examples:
   allure-report-publisher upload s3 --results-glob='path/to/allure-results' --bucket=my-bucket
   allure-report-publisher upload gcs --results-glob='paths/to/**/allure-results' --bucket=my-bucket --prefix=my-project/prs
+  allure-report-publisher upload gitlab-artifacts --results-glob='paths/to/**/allure-results'
 ```
 
 ## Extra arguments
@@ -114,6 +114,23 @@ credentials.json contents:
 - `GOOGLE_CLOUD_CREDENTIALS_JSON`
 - `GOOGLE_CLOUD_KEYFILE_JSON`
 - `GCLOUD_KEYFILE_JSON`
+
+## Gitlab Artifacts
+
+This storage provider is only supported for GitLab CI. Because GitLab does not expose public api for uploading artifacts, a job must be configured to upload the report as an artifact. Example:
+
+```yaml
+# .gitlab-ci.yml
+artifacts:
+  paths:
+    - allure-report
+```
+
+where `allure-report` is the directory containing the generated Allure report and can be overridden via `--output` option.
+
+Requires environment variable `GITLAB_AUTH_TOKEN` where token is a GitLab personal access token with `api` scope capable of downloading artifacts and retrieving job and pipeline information.
+
+This provider is meant to be used with [GitLab CI](#gitlab-ci).
 
 # CI
 

--- a/lib/allure_report_publisher/commands/upload.rb
+++ b/lib/allure_report_publisher/commands/upload.rb
@@ -234,10 +234,11 @@ module Publisher
       # @return [void]
       def upload_report
         log("Uploading allure report to #{args[:type]}")
+        # gitlab-artifacts by default will raise error with info about upload using artifacts
         spinner_args = {
           debug: args[:debug],
           exit_on_error: !gitlab_artifacts?,
-          done_message: gitlab_artifacts? ? "skipped" : nil
+          failed_message: gitlab_artifacts? ? "skipped" : nil
         }.compact
         Spinner.spin("uploading", **spinner_args) { uploader.upload }
         uploader.report_urls.each { |k, v| log("#{k}: #{v}", :green) }

--- a/lib/allure_report_publisher/lib/helpers/helpers.rb
+++ b/lib/allure_report_publisher/lib/helpers/helpers.rb
@@ -64,6 +64,18 @@ module Publisher
       ENV[name]
     end
 
+    # Return environment variable as integer if it's numeric
+    #
+    # @param [String] name
+    # @return [Integer, nil]
+    def env_int(name)
+      value = env(name)
+      return unless value
+      raise("Invalid integer value for #{name}: #{value}") unless value.match?(/\A-?\d+\z/)
+
+      value.to_i
+    end
+
     module_function
 
     # Colorize string

--- a/lib/allure_report_publisher/lib/helpers/helpers.rb
+++ b/lib/allure_report_publisher/lib/helpers/helpers.rb
@@ -71,7 +71,7 @@ module Publisher
     def env_int(name)
       value = env(name)
       return unless value
-      raise("Invalid integer value for #{name}: #{value}") unless value.match?(/\A-?\d+\z/)
+      raise("Invalid integer value for #{name}") unless value.match?(/\A-?\d+\z/)
 
       value.to_i
     end

--- a/lib/allure_report_publisher/lib/helpers/spinner.rb
+++ b/lib/allure_report_publisher/lib/helpers/spinner.rb
@@ -24,20 +24,27 @@ module Publisher
       # @param [Boolean] exit_on_error
       # @param [Proc] &block
       # @return [void]
-      def self.spin(spinner_message, done_message: "done", exit_on_error: true, debug: false, &block)
-        new(spinner_message, exit_on_error: exit_on_error, debug: debug).spin(done_message, &block)
+      def self.spin(
+        spinner_message,
+        done_message: "done",
+        failed_message: "failed",
+        exit_on_error: true,
+        debug: false,
+        &block
+      )
+        new(spinner_message, exit_on_error: exit_on_error, debug: debug).spin(done_message, failed_message, &block)
       end
 
       # Run code block inside spinner
       #
       # @param [String] done_message
       # @return [Boolean]
-      def spin(done_message = "done")
+      def spin(done_message = "done", failed_message = "failed")
         spinner.auto_spin
         yield
         spinner_success(done_message)
       rescue StandardError => e
-        spinner_error(e, done_message: exit_on_error ? "failed" : done_message)
+        spinner_error(e, done_message: failed_message)
         raise(Failure, e.message) if exit_on_error
       ensure
         print_debug

--- a/lib/allure_report_publisher/lib/helpers/spinner.rb
+++ b/lib/allure_report_publisher/lib/helpers/spinner.rb
@@ -37,7 +37,7 @@ module Publisher
         yield
         spinner_success(done_message)
       rescue StandardError => e
-        spinner_error(e)
+        spinner_error(e, done_message: exit_on_error ? "failed" : done_message)
         raise(Failure, e.message) if exit_on_error
       ensure
         print_debug
@@ -119,8 +119,8 @@ module Publisher
     #
     # @param [StandardError] error
     # @return [void]
-    def spinner_error(error)
-      message = ["failed", error.message]
+    def spinner_error(error, done_message: "failed")
+      message = [done_message, error.message]
       log_debug("Error: #{error.message}\n#{error.backtrace.join("\n")}")
 
       colored_message = colorize(message.compact.join("\n"), error_color)

--- a/lib/allure_report_publisher/lib/providers/github.rb
+++ b/lib/allure_report_publisher/lib/providers/github.rb
@@ -19,18 +19,8 @@ module Publisher
       def_delegators :"Publisher::Providers::Info::Github.instance",
                      :repository,
                      :server_url,
-                     :build_name
-
-      # Github api client
-      #
-      # @return [Octokit::Client]
-      def client
-        @client ||= begin
-          raise("Missing GITHUB_AUTH_TOKEN environment variable!") unless ENV["GITHUB_AUTH_TOKEN"]
-
-          Octokit::Client.new(access_token: ENV["GITHUB_AUTH_TOKEN"], api_endpoint: ENV["GITHUB_API_URL"])
-        end
-      end
+                     :build_name,
+                     :client
 
       # Update pull request description
       #

--- a/lib/allure_report_publisher/lib/providers/gitlab.rb
+++ b/lib/allure_report_publisher/lib/providers/gitlab.rb
@@ -15,21 +15,8 @@ module Publisher
                      :mr_iid,
                      :allure_mr_iid,
                      :server_url,
-                     :build_name
-
-      # Get gitlab client
-      #
-      # @return [Gitlab::Client]
-      def client
-        @client ||= begin
-          raise("Missing GITLAB_AUTH_TOKEN environment variable!") unless env("GITLAB_AUTH_TOKEN")
-
-          ::Gitlab::Client.new(
-            endpoint: "#{server_url}/api/v4",
-            private_token: env("GITLAB_AUTH_TOKEN")
-          )
-        end
-      end
+                     :build_name,
+                     :client
 
       # Current pull request description
       #

--- a/lib/allure_report_publisher/lib/providers/info/_base.rb
+++ b/lib/allure_report_publisher/lib/providers/info/_base.rb
@@ -11,6 +11,13 @@ module Publisher
 
         # :nocov:
 
+        # CI provider api client
+        #
+        # @return [Object]
+        def client
+          raise("Not implemented!")
+        end
+
         # CI Provider executor info
         #
         # @param [String] report_url

--- a/lib/allure_report_publisher/lib/providers/info/github.rb
+++ b/lib/allure_report_publisher/lib/providers/info/github.rb
@@ -23,6 +23,17 @@ module Publisher
           }
         end
 
+        # Github api client
+        #
+        # @return [Octokit::Client]
+        def client
+          @client ||= begin
+            raise("Missing GITHUB_AUTH_TOKEN environment variable!") unless ENV["GITHUB_AUTH_TOKEN"]
+
+            Octokit::Client.new(access_token: ENV["GITHUB_AUTH_TOKEN"], api_endpoint: ENV["GITHUB_API_URL"])
+          end
+        end
+
         # Pull request run
         #
         # @return [Boolean]

--- a/lib/allure_report_publisher/lib/providers/info/gitlab.rb
+++ b/lib/allure_report_publisher/lib/providers/info/gitlab.rb
@@ -23,6 +23,20 @@ module Publisher
           }
         end
 
+        # Get gitlab client
+        #
+        # @return [Gitlab::Client]
+        def client
+          @client ||= begin
+            raise("Missing GITLAB_AUTH_TOKEN environment variable!") unless env("GITLAB_AUTH_TOKEN")
+
+            ::Gitlab::Client.new(
+              endpoint: "#{server_url}/api/v4",
+              private_token: env("GITLAB_AUTH_TOKEN")
+            )
+          end
+        end
+
         # Pull request run
         #
         # @return [Boolean]
@@ -35,6 +49,38 @@ module Publisher
         # @return [String]
         def run_id
           @run_id ||= env(ALLURE_RUN_ID) || ENV["CI_PIPELINE_ID"]
+        end
+
+        # CI job ID
+        #
+        # @return [String]
+        def job_id
+          @job_id ||= env(ALLURE_JOB_ID) || ENV["CI_JOB_ID"]
+        end
+
+        # Gitlab pages hostname
+        #
+        # @return [String]
+        def pages_hostname
+          @pages_hostname ||= ENV["CI_PAGES_HOSTNAME"]
+        end
+
+        # CI project name
+        #
+        # @return [String]
+        def project_name
+          @project_name ||= ENV["CI_PROJECT_NAME"]
+        end
+
+        # Project directory
+        #
+        # @return [String] project directory
+        def project_dir
+          @project_dir ||= ENV["CI_PROJECT_DIR"]
+        end
+
+        def branch
+          @branch ||= ENV["CI_MERGE_REQUEST_SOURCE_BRANCH_NAME"] || ENV["CI_COMMIT_REF_NAME"]
         end
 
         # Server url

--- a/lib/allure_report_publisher/lib/providers/info/gitlab.rb
+++ b/lib/allure_report_publisher/lib/providers/info/gitlab.rb
@@ -48,14 +48,14 @@ module Publisher
         #
         # @return [Integer]
         def run_id
-          @run_id ||= (env(ALLURE_RUN_ID) || env("CI_PIPELINE_ID")).to_i
+          @run_id ||= env_int(ALLURE_RUN_ID) || env_int("CI_PIPELINE_ID")
         end
 
         # CI job ID
         #
         # @return [Integer]
         def job_id
-          @job_id ||= env("CI_JOB_ID").to_i
+          @job_id ||= env_int("CI_JOB_ID")
         end
 
         # Gitlab pages hostname
@@ -76,7 +76,7 @@ module Publisher
         #
         # @return [Integer]
         def project_id
-          @project_id ||= env("CI_PROJECT_ID").to_i
+          @project_id ||= env_int("CI_PROJECT_ID")
         end
 
         # Project directory
@@ -115,14 +115,14 @@ module Publisher
         #
         # @return [Integer]
         def mr_iid
-          @mr_iid ||= (allure_mr_iid || env("CI_MERGE_REQUEST_IID")).to_i
+          @mr_iid ||= allure_mr_iid || env_int("CI_MERGE_REQUEST_IID")
         end
 
         # Custom mr iid name
         #
         # @return [Integer]
         def allure_mr_iid
-          @allure_mr_iid ||= env("ALLURE_MERGE_REQUEST_IID").to_i
+          @allure_mr_iid ||= env_int("ALLURE_MERGE_REQUEST_IID")
         end
 
         # Job name used in report

--- a/lib/allure_report_publisher/lib/providers/info/gitlab.rb
+++ b/lib/allure_report_publisher/lib/providers/info/gitlab.rb
@@ -46,41 +46,48 @@ module Publisher
 
         # Get ci run ID without creating instance of ci provider
         #
-        # @return [String]
+        # @return [Integer]
         def run_id
-          @run_id ||= env(ALLURE_RUN_ID) || ENV["CI_PIPELINE_ID"]
+          @run_id ||= (env(ALLURE_RUN_ID) || env("CI_PIPELINE_ID")).to_i
         end
 
         # CI job ID
         #
-        # @return [String]
+        # @return [Integer]
         def job_id
-          @job_id ||= env(ALLURE_JOB_ID) || ENV["CI_JOB_ID"]
+          @job_id ||= env("CI_JOB_ID").to_i
         end
 
         # Gitlab pages hostname
         #
         # @return [String]
         def pages_hostname
-          @pages_hostname ||= ENV["CI_PAGES_HOSTNAME"]
+          @pages_hostname ||= env("CI_PAGES_HOSTNAME")
         end
 
         # CI project name
         #
         # @return [String]
         def project_name
-          @project_name ||= ENV["CI_PROJECT_NAME"]
+          @project_name ||= env("CI_PROJECT_NAME")
+        end
+
+        # CI project ID
+        #
+        # @return [Integer]
+        def project_id
+          @project_id ||= env("CI_PROJECT_ID").to_i
         end
 
         # Project directory
         #
-        # @return [String] project directory
-        def project_dir
-          @project_dir ||= ENV["CI_PROJECT_DIR"]
+        # @return [String] build directory
+        def build_dir
+          @build_dir ||= env("CI_PROJECT_DIR")
         end
 
         def branch
-          @branch ||= ENV["CI_MERGE_REQUEST_SOURCE_BRANCH_NAME"] || ENV["CI_COMMIT_REF_NAME"]
+          @branch ||= env("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME") || env("CI_COMMIT_REF_NAME")
         end
 
         # Server url
@@ -108,21 +115,28 @@ module Publisher
         #
         # @return [Integer]
         def mr_iid
-          @mr_iid ||= allure_mr_iid || env("CI_MERGE_REQUEST_IID")
+          @mr_iid ||= (allure_mr_iid || env("CI_MERGE_REQUEST_IID")).to_i
         end
 
         # Custom mr iid name
         #
-        # @return [String]
+        # @return [Integer]
         def allure_mr_iid
-          @allure_mr_iid ||= env("ALLURE_MERGE_REQUEST_IID")
+          @allure_mr_iid ||= env("ALLURE_MERGE_REQUEST_IID").to_i
         end
 
-        # Job name
+        # Job name used in report
         #
         # @return [String]
         def build_name
-          @build_name ||= env(ALLURE_JOB_NAME) || env("CI_JOB_NAME")
+          @build_name ||= env(ALLURE_JOB_NAME) || job_name
+        end
+
+        # CI job name
+        #
+        # @return [String]
+        def job_name
+          @job_name ||= env("CI_JOB_NAME")
         end
       end
     end

--- a/lib/allure_report_publisher/lib/report_generator.rb
+++ b/lib/allure_report_publisher/lib/report_generator.rb
@@ -10,7 +10,7 @@ module Publisher
   class ReportGenerator
     include Helpers
 
-    def initialize(result_paths, report_name, report_path = File.join(Dir.tmpdir, "allure-report-#{Time.now.to_i}"))
+    def initialize(result_paths, report_name, report_path)
       @result_paths = result_paths.join(" ")
       @report_name = report_name
       @report_path = report_path

--- a/lib/allure_report_publisher/lib/report_generator.rb
+++ b/lib/allure_report_publisher/lib/report_generator.rb
@@ -10,9 +10,10 @@ module Publisher
   class ReportGenerator
     include Helpers
 
-    def initialize(result_paths, report_name)
+    def initialize(result_paths, report_name, report_path = File.join(Dir.tmpdir, "allure-report-#{Time.now.to_i}"))
       @result_paths = result_paths.join(" ")
       @report_name = report_name
+      @report_path = report_path
     end
 
     # Generate allure report
@@ -35,12 +36,8 @@ module Publisher
     end
     alias create_common_path common_info_path
 
-    # Allure report directory
-    #
-    # @return [String]
-    def report_path
-      @report_path ||= File.join(Dir.tmpdir, "allure-report-#{Time.now.to_i}")
-    end
+    # @return [String] report path
+    attr_reader :report_path
 
     private
 

--- a/lib/allure_report_publisher/lib/uploaders/_uploader.rb
+++ b/lib/allure_report_publisher/lib/uploaders/_uploader.rb
@@ -213,7 +213,7 @@ module Publisher
         end
       end
 
-      # Fetch allure report history
+      # Create allure report history dir
       #
       # @return [void]
       def create_history_dir

--- a/lib/allure_report_publisher/lib/uploaders/_uploader.rb
+++ b/lib/allure_report_publisher/lib/uploaders/_uploader.rb
@@ -38,6 +38,7 @@ module Publisher
         @copy_latest = ci_info && args[:copy_latest] # copy latest for ci only
         @report_name = args[:report_name]
         @parallel = args[:parallel]
+        @report_path = args[:output] || File.join(Dir.tmpdir, "allure-report-#{Time.now.to_i}")
       end
 
       # Generate allure report
@@ -90,7 +91,8 @@ module Publisher
                   :base_url,
                   :copy_latest,
                   :report_name,
-                  :parallel
+                  :parallel,
+                  :report_path
 
       def_delegator :report_generator, :common_info_path
 
@@ -151,7 +153,7 @@ module Publisher
       #
       # @return [Publisher::ReportGenerator]
       def report_generator
-        @report_generator ||= ReportGenerator.new(result_paths, report_name)
+        @report_generator ||= ReportGenerator.new(result_paths, report_name, report_path)
       end
 
       # Report path prefix

--- a/lib/allure_report_publisher/lib/uploaders/_uploader.rb
+++ b/lib/allure_report_publisher/lib/uploaders/_uploader.rb
@@ -30,6 +30,7 @@ module Publisher
       # @option args [String] :copy_latest
       # @option args [String] :report_name
       # @option args [Integer] :parallel
+      # @option args [String] :output
       def initialize(**args)
         @result_paths = args[:result_paths]
         @bucket_name = args[:bucket]
@@ -38,7 +39,7 @@ module Publisher
         @copy_latest = ci_info && args[:copy_latest] # copy latest for ci only
         @report_name = args[:report_name]
         @parallel = args[:parallel]
-        @report_path = args[:output] || File.join(Dir.tmpdir, "allure-report-#{Time.now.to_i}")
+        @report_path = args[:output]
       end
 
       # Generate allure report

--- a/lib/allure_report_publisher/lib/uploaders/gitlab_artifacts.rb
+++ b/lib/allure_report_publisher/lib/uploaders/gitlab_artifacts.rb
@@ -1,0 +1,150 @@
+module Publisher
+  module Uploaders
+    # Uploads artifacts to GitLab
+    #
+    class GitlabArtifacts < Uploader
+      extend Forwardable
+
+      def initialize
+        super
+
+        # gitlab artifacts do not support having url to latest report
+        @copy_latest = false
+      end
+
+      # Report url
+      #
+      # @return [String]
+      def report_url
+        @report_url ||= "https://#{pages_hostname}/-/#{project_name}/-/jobs/#{job_id}/artifacts/#{report_path}/index.html"
+      end
+
+      # No-op method as gitlab does not expose api to upload artifacts
+      #
+      # @return [void]
+      def upload; end
+
+      private
+
+      def_delegators :ci_info,
+                     :pages_hostname,
+                     :project_name,
+                     :project_id,
+                     :job_id,
+                     :job_name,
+                     :branch,
+                     :build_name,
+                     :server_url,
+                     :client
+
+      # Download allure history
+      #
+      # @return [void]
+      def download_history
+        log_debug("Downloading allure history")
+
+        job_id = previous_job_id || previous_pipeline_job_id
+        unless job_id
+          log_debug("No previous job with artifacts found")
+          return
+        end
+
+        log_debug("Fetching history from artifacts of job: #{job_id}")
+        HISTORY.each do |file_name|
+          download_artifact_file(
+            job_id,
+            "#{report_path}/history/#{file_name}",
+            path(common_info_path, "history", file_name)
+          )
+        end
+      end
+
+      # Previous job id within the same pipeline
+      #
+      # @return [Integer, nil] job id or nil if not found
+      def previous_job_id
+        return @previous_job_id if defined?(@previous_job_id)
+
+        jobs = client.pipeline_jobs(
+          project_id,
+          pipeline_id,
+          include_retried: true,
+          scope: %w[success failed]
+        ).map(&:id)
+        return @previous_job_id = nil if jobs.size < 2
+
+        @previous_job_id = jobs[jobs.index(job_id.to_i) - 1]
+      end
+
+      # Last job from previous pipeline
+      #
+      # @return [Integer, nil] job id or nil if not found
+      def previous_pipeline_job_id
+        return @previous_pipeline_job_id if defined?(@previous_pipeline_job_id)
+
+        pipelines = client.pipelines(
+          project_id,
+          ref: branch,
+          per_page: 50
+        ).map(&:id)
+        return @previous_pipeline_job_id = nil if pipelines.size < 2
+
+        previous_index = pipelines.index(pipeline_id.to_i) - 1
+        return @previous_pipeline_job_id = nil if previous_index.negative?
+
+        @previous_pipeline_job_id = client.pipeline_jobs(
+          project_id,
+          pipelines[previous_index],
+          scope: %w[success failed]
+        ).find { |job| job.name == build_name }&.id
+      end
+
+      # Report path
+      #
+      # @return [String]
+      def report_path
+        @report_path ||= File.join(ci_info.project_dir, "allure-report")
+      end
+
+      # Allure report generator
+      #
+      # @return [Publisher::ReportGenerator]
+      def report_generator
+        @report_generator ||= ReportGenerator.new(result_paths, report_name, report_path)
+      end
+
+      # Current ref pipelines
+      #
+      # @return [Array<Hash>]
+      def pipelines
+        @pipelines ||= client.pipelines(project_id, ref: branch, per_page: 10)
+      end
+
+      def latest_job
+        @latest_job ||= pipelines.max_by(&:id)
+      end
+
+      # CI info
+      #
+      # @return [Providers::Info::Gitlab]
+      def ci_info
+        Providers::Info::Gitlab.instance
+      end
+
+      # Download specific artifact file
+      #
+      # @param job_id [Integer] job id
+      # @param artifact_path [String] path within artifacts
+      # @param local_path [String] local file path to save
+      # @return [void]
+      def download_artifact_file(job_id, artifact_path, local_path)
+        log_debug("Downloading artifact file: #{artifact_path} to #{local_path}")
+        # this will only work with history json files, see: https://github.com/NARKOZ/gitlab/issues/621
+        response = client.download_job_artifact_file(project_id, job_id, artifact_path)
+
+        FileUtils.mkdir_p(File.dirname(local_path))
+        File.write(local_path, response.to_json)
+      end
+    end
+  end
+end

--- a/lib/allure_report_publisher/lib/uploaders/gitlab_artifacts.rb
+++ b/lib/allure_report_publisher/lib/uploaders/gitlab_artifacts.rb
@@ -5,13 +5,11 @@ module Publisher
     class GitlabArtifacts < Uploader
       extend Forwardable
 
-      def initialize(...)
+      def initialize(**args)
         super
 
         # gitlab artifacts do not support having url to latest report
         @copy_latest = false
-        # gitlab artifacts must use path relative to build dir instead of global tmp folder
-        @report_path = args[:output] || "allure-report"
       end
 
       # Report url

--- a/lib/allure_report_publisher/lib/uploaders/gitlab_artifacts.rb
+++ b/lib/allure_report_publisher/lib/uploaders/gitlab_artifacts.rb
@@ -115,7 +115,6 @@ module Publisher
         # this will only work with history json files, see: https://github.com/NARKOZ/gitlab/issues/621
         response = client.download_job_artifact_file(project_id, job_id, artifact_path)
 
-        FileUtils.mkdir_p(File.dirname(local_path))
         File.write(local_path, response.to_json)
       end
     end

--- a/spec/allure_report_publisher/commands/common_uploader_command.rb
+++ b/spec/allure_report_publisher/commands/common_uploader_command.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples "upload command" do
   let(:prefix) { "my-project/prs" }
   let(:report_title) { "Allure Report" }
   let(:report_url) { "http://report.com" }
-  let(:report_path) { "path/to/report" }
+  let(:output) { /allure-report-*/ }
 
   let(:uploader_stub) do
     instance_double(
@@ -16,8 +16,7 @@ RSpec.shared_examples "upload command" do
       generate_report: nil,
       upload: nil,
       report_urls: { "Report url" => report_url },
-      report_url: report_url,
-      report_path: report_path
+      report_url: report_url
     )
   end
 
@@ -38,14 +37,15 @@ RSpec.shared_examples "upload command" do
       bucket: bucket,
       prefix: prefix,
       copy_latest: false,
-      parallel: 8
+      parallel: 8,
+      output: output
     }
   end
 
   let(:provider_args) do
     {
       report_url: report_url,
-      report_path: report_path,
+      report_path: output,
       summary_type: Publisher::Helpers::Summary::TOTAL,
       summary_table_type: Publisher::Helpers::Summary::ASCII,
       collapse_summary: false,

--- a/spec/allure_report_publisher/lib/providers/gitlab_env.rb
+++ b/spec/allure_report_publisher/lib/providers/gitlab_env.rb
@@ -1,12 +1,12 @@
 require "tempfile"
 
 RSpec.shared_context "with gitlab env" do
-  let(:mr_id) { "1" }
+  let(:mr_id) { 1 }
   let(:event_name) { "merge_request_event" }
   let(:custom_project) { nil }
   let(:custom_mr_id) { nil }
   let(:auth_token) { "token" }
-  let(:run_id) { "123" }
+  let(:run_id) { 123 }
   let(:sha) { "cfdef23b4b06df32ab1e98ee4091504948daf2a9" }
 
   let(:env) do
@@ -14,16 +14,16 @@ RSpec.shared_context "with gitlab env" do
       GITLAB_CI: "true",
       CI_SERVER_URL: "https://gitlab.com",
       CI_JOB_NAME: "test",
-      CI_PIPELINE_ID: run_id,
+      CI_PIPELINE_ID: run_id.to_s,
       CI_PIPELINE_URL: "https://gitlab.com/pipeline/url",
       CI_PROJECT_PATH: "project",
-      CI_MERGE_REQUEST_IID: mr_id,
+      CI_MERGE_REQUEST_IID: mr_id.to_s,
       CI_PIPELINE_SOURCE: event_name,
       CI_MERGE_REQUEST_SOURCE_BRANCH_SHA: "",
       CI_COMMIT_SHA: sha,
       GITLAB_AUTH_TOKEN: auth_token,
       ALLURE_PROJECT_PATH: custom_project,
-      ALLURE_MERGE_REQUEST_IID: custom_mr_id
+      ALLURE_MERGE_REQUEST_IID: custom_mr_id&.positive? ? custom_mr_id.to_s : nil
     }.compact
   end
 

--- a/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
+++ b/spec/allure_report_publisher/lib/providers/gitlab_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Publisher::Providers::Gitlab, epic: "providers" do
   context "with overridden parameters" do
     let(:event_name) { "push" }
     let(:custom_project) { "custom/project" }
-    let(:custom_mr_id) { "123" }
+    let(:custom_mr_id) { 123 }
     let(:sha_url) { custom_sha_url }
 
     it "updates mr description with custom parameters for non mr runs" do

--- a/spec/allure_report_publisher/lib/uploaders/common_uploader.rb
+++ b/spec/allure_report_publisher/lib/uploaders/common_uploader.rb
@@ -36,6 +36,7 @@ RSpec.shared_context "with uploader" do
       base_url: base_url,
       copy_latest: false,
       report_name: report_name,
+      output: report_path,
       parallel: 8
     }
   end

--- a/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
       execute(allure_extra_args: ["--lang=en"])
 
       aggregate_failures do
-        expect(Publisher::ReportGenerator).to have_received(:new).with(result_paths, report_name)
+        expect(Publisher::ReportGenerator).to have_received(:new).with(result_paths, report_name, report_path)
         expect(report_generator).to have_received(:generate).with(["--lang=en"])
       end
     end

--- a/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/gcs_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe Publisher::Uploaders::GCS, epic: "uploaders" do
 
     it "adds executor info" do
       execute
+
       expect(File).to have_received(:write)
         .with("#{common_info_path}/executor.json", JSON.pretty_generate(executor_info)).twice
     end

--- a/spec/allure_report_publisher/lib/uploaders/gitlab_artifacts_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/gitlab_artifacts_spec.rb
@@ -1,0 +1,288 @@
+require_relative "common_uploader"
+require_relative "../providers/gitlab_env"
+
+RSpec.describe Publisher::Uploaders::GitlabArtifacts, epic: "uploaders" do
+  include_context "with uploader"
+  include_context "with gitlab env"
+
+  let(:client) do
+    instance_double(
+      Gitlab::Client,
+      pipelines: pipelines_response,
+      pipeline_jobs: jobs_response,
+      download_job_artifact_file: artifact_response
+    )
+  end
+
+  let(:pipelines_response) do
+    [
+      double("pipeline", id: current_pipeline_id),
+      double("pipeline", id: previous_pipeline_id),
+      double("pipeline", id: older_pipeline_id)
+    ]
+  end
+
+  let(:jobs_response) do
+    [
+      double("job", name: "test", id: previous_job_id),
+      double("job", name: "other", id: 999)
+    ]
+  end
+
+  let(:artifact_response) { { "key" => "value" } }
+  let(:current_pipeline_id) { 123 }
+  let(:previous_pipeline_id) { 122 }
+  let(:older_pipeline_id) { 121 }
+  let(:previous_job_id) { 456 }
+  let(:job_name) { "test" }
+  let(:job_id) { "789" }
+  let(:pages_hostname) { "gitlab.example.com" }
+  let(:project_name) { "project" }
+  let(:project_id) { "123" }
+  let(:branch) { "main" }
+  let(:run_id) { current_pipeline_id }
+
+  let(:ci_info) do
+    instance_double(
+      Publisher::Providers::Info::Gitlab,
+      pages_hostname: pages_hostname,
+      project_name: project_name,
+      project_id: project_id,
+      job_name: job_name,
+      job_id: job_id,
+      branch: branch,
+      build_dir: "build",
+      build_name: job_name,
+      server_url: "https://gitlab.example.com",
+      client: client,
+      run_id: run_id,
+      executor: {}
+    )
+  end
+
+  before do
+    allow(Publisher::Providers::Info::Gitlab).to receive(:instance).and_return(ci_info)
+    allow(File).to receive(:write)
+    allow(File).to receive(:exist?).and_return(false)
+    allow(FileUtils).to receive(:mkdir_p).and_return(["/tmp/history"])
+  end
+
+  def execute(allure_extra_args: [], **extra_args)
+    uploader = described_class.new(**args, **extra_args)
+    uploader.generate_report(allure_extra_args)
+  end
+
+  context "with initialization" do
+    it "sets copy_latest to false" do
+      uploader = described_class.new(**args)
+      expect(uploader.instance_variable_get(:@copy_latest)).to be false
+    end
+  end
+
+  context "with report url generation" do
+    it "returns correct GitLab artifacts report url" do
+      uploader = described_class.new(**args)
+      expected_url = "https://#{pages_hostname}/-/#{project_name}/-/jobs/#{job_id}/artifacts/#{report_path}/index.html"
+
+      expect(uploader.report_url).to eq(expected_url)
+    end
+  end
+
+  context "with upload operation" do
+    it "raises error when upload is called" do
+      uploader = described_class.new(**args)
+
+      expect { uploader.upload }.to raise_error(
+        "Gitlab artifacts does not support upload operation! Report upload must be configured in the CI job."
+      )
+    end
+  end
+
+  context "with report generation" do
+    it "generates allure report" do
+      execute(allure_extra_args: ["--lang=en"])
+
+      aggregate_failures do
+        expect(Publisher::ReportGenerator).to have_received(:new).with(result_paths, report_name, report_path)
+        expect(report_generator).to have_received(:generate).with(["--lang=en"])
+      end
+    end
+
+    it "fetches and saves history info when previous job exists" do
+      execute
+
+      aggregate_failures do
+        expect(client).to have_received(:pipelines).with(
+          project_id,
+          ref: branch,
+          per_page: 50
+        )
+        expect(client).to have_received(:pipeline_jobs).with(
+          project_id,
+          previous_pipeline_id,
+          scope: %w[success failed]
+        )
+
+        history_files.each do |file_name|
+          expect(client).to have_received(:download_job_artifact_file).with(
+            project_id,
+            previous_job_id,
+            "#{report_path}/history/#{file_name}"
+          )
+        end
+      end
+    end
+  end
+
+  context "with history download" do
+    context "when no previous job exists" do
+      let(:pipelines_response) { [double("pipeline", id: current_pipeline_id)] }
+
+      it "skips history download" do
+        execute
+
+        expect(client).not_to have_received(:download_job_artifact_file)
+      end
+    end
+
+    context "when previous pipeline has no matching job" do
+      let(:jobs_response) do
+        [
+          double("job", name: "different-job", id: 999)
+        ]
+      end
+
+      it "skips history download" do
+        execute
+
+        expect(client).not_to have_received(:download_job_artifact_file)
+      end
+    end
+
+    context "when multiple pipelines exist with matching job" do
+      it "finds and uses correct previous job ID for history download" do
+        execute
+
+        aggregate_failures do
+          expect(client).to have_received(:pipelines).with(
+            project_id,
+            ref: branch,
+            per_page: 50
+          )
+          expect(client).to have_received(:pipeline_jobs).with(
+            project_id,
+            previous_pipeline_id,
+            scope: %w[success failed]
+          )
+
+          # Verify the correct previous job ID was found and used
+          history_files.each do |file_name|
+            expect(client).to have_received(:download_job_artifact_file).with(
+              project_id,
+              previous_job_id,
+              "#{report_path}/history/#{file_name}"
+            )
+          end
+        end
+      end
+    end
+
+    context "when artifact download succeeds" do
+      it "saves artifact files as JSON" do
+        execute
+
+        expect(FileUtils).to have_received(:mkdir_p).with(File.join(common_info_path, "history"))
+
+        history_files.each do |file_name|
+          file_path = File.join(common_info_path, "history", file_name)
+          expect(File).to have_received(:write).with(file_path, artifact_response.to_json)
+        end
+      end
+    end
+  end
+
+  context "with executor info" do
+    context "when executor file doesn't exist" do
+      before do
+        allow(File).to receive(:exist?).and_return(false)
+      end
+
+      it "writes executor info to both common_info_path and result_paths" do
+        execute
+
+        expect(File).to have_received(:write).with("#{common_info_path}/executor.json", JSON.pretty_generate({})).twice
+      end
+    end
+
+    context "when executor file already exists" do
+      before do
+        allow(File).to receive(:exist?).and_return(true)
+      end
+
+      it "skips writing executor info" do
+        execute
+
+        expect(File).not_to have_received(:write).with("#{common_info_path}/executor.json", anything)
+      end
+    end
+  end
+
+  context "with report URLs" do
+    it "returns only report url (no latest report url)" do
+      uploader = described_class.new(**args, copy_latest: true)
+      expected_url = "https://#{pages_hostname}/-/#{project_name}/-/jobs/#{job_id}/artifacts/#{report_path}/index.html"
+
+      expect(uploader.report_urls).to eq({
+        "Report url" => expected_url
+      })
+    end
+  end
+
+  context "with artifact file download integration" do
+    # Test the artifact download behavior through the public generate_report method
+    # which internally calls download_artifact_file for each history file
+
+    context "when downloading multiple artifact files" do
+      it "downloads all history files and saves them as JSON" do
+        execute
+
+        aggregate_failures do
+          # Verify all history files were requested from the correct job
+          history_files.each do |file_name|
+            expect(client).to have_received(:download_job_artifact_file).with(
+              project_id,
+              previous_job_id,
+              "#{report_path}/history/#{file_name}"
+            )
+
+            file_path = File.join(common_info_path, "history", file_name)
+            expect(File).to have_received(:write).with(file_path, artifact_response.to_json)
+          end
+
+          # Verify directory was created
+          expect(FileUtils).to have_received(:mkdir_p).with(File.join(common_info_path, "history"))
+        end
+      end
+    end
+
+    context "when artifact download encounters network errors" do
+      before do
+        # Use HistoryNotFoundError which is the expected error type that gets handled
+        allow(client).to receive(:download_job_artifact_file).and_raise(
+          Publisher::Uploaders::HistoryNotFoundError, "History not found"
+        )
+      end
+
+      it "handles history download errors gracefully and continues" do
+        # The uploader should handle HistoryNotFoundError without crashing
+        expect { execute }.not_to raise_error
+
+        # Should still try to download history files
+        expect(client).to have_received(:download_job_artifact_file)
+
+        # But no files should be written due to the error
+        expect(File).not_to have_received(:write).with(anything, artifact_response.to_json)
+      end
+    end
+  end
+end

--- a/spec/allure_report_publisher/lib/uploaders/s3_spec.rb
+++ b/spec/allure_report_publisher/lib/uploaders/s3_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Publisher::Uploaders::S3, epic: "uploaders" do
       execute(allure_extra_args: ["--lang=en"])
 
       aggregate_failures do
-        expect(Publisher::ReportGenerator).to have_received(:new).with(result_paths, report_name)
+        expect(Publisher::ReportGenerator).to have_received(:new).with(result_paths, report_name, report_path)
         expect(report_generator).to have_received(:generate).with(["--lang=en"])
       end
     end


### PR DESCRIPTION
Add support to use gitlab job artifacts for report storage.

This change introduces new storage type option `gitlab-artifacts` and also new option `--output` which sets output directory for generated allure report