### PR TITLE
Use same pipeline source scope fore previous run lookup

### DIFF
--- a/src/lib/ci/info/gitlab.ts
+++ b/src/lib/ci/info/gitlab.ts
@@ -66,4 +66,8 @@ export class GitlabCiInfo extends BaseCiInfo {
   public get pagesDomain() {
     return process.env.CI_PAGES_DOMAIN
   }
+
+  public get pipelineSource() {
+    return process.env.CI_PIPELINE_SOURCE
+  }
 }

--- a/src/lib/uploader/gitlab-artifacts.ts
+++ b/src/lib/uploader/gitlab-artifacts.ts
@@ -86,7 +86,7 @@ export class GitlabArtifactsUploader extends BaseUploader {
   }
 
   private async getPreviousJobId() {
-    const {projectId, branch, buildName, runId} = this.ciInfo
+    const {projectId, branch, buildName, runId, pipelineSource} = this.ciInfo
 
     if (!projectId || !branch || !buildName || !runId) {
       throw new Error('Missing required CI info for fetching previous job ID')
@@ -95,6 +95,7 @@ export class GitlabArtifactsUploader extends BaseUploader {
     logger.debug(`Fetching previous pipelines for ref: ${branch}`)
     const pipelines = await this.client.Pipelines.all(projectId, {
       ref: branch,
+      source: pipelineSource,
       perPage: 100,
       maxPages: 1,
     })


### PR DESCRIPTION
Use same source when fetching previous pipelines for history lookup